### PR TITLE
python client tests for drive with pedestrians, cpp client agent attribute bug fixes

### DIFF
--- a/invertedai_cpp/Dockerfile
+++ b/invertedai_cpp/Dockerfile
@@ -16,4 +16,6 @@ RUN curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor >bazel-
 COPY . /usr/src/myapp
 WORKDIR /usr/src/myapp
 
+RUN chmod 755 ./run_all_tests.sh
+
 CMD ["/bin/bash"]

--- a/invertedai_cpp/examples/BUILD
+++ b/invertedai_cpp/examples/BUILD
@@ -45,3 +45,31 @@ cc_binary(
         "@opencv",
     ],
 )
+
+cc_binary(
+    name = "initialize_tests",
+    srcs = ["initialize_tests.cc"],
+    data = [
+        "initialize_body.json",
+        "initialize_sampling_with_types.json",
+        "initialize_with_states_and_attributes.json",
+    ],
+    deps = [
+        "//invertedai:api",
+        "@boost//:beast",
+        "@opencv",
+    ],
+)
+
+cc_binary(
+    name = "drive_tests",
+    srcs = ["drive_tests.cc"],
+    data = [
+        "drive_body.json",
+    ],
+    deps = [
+        "//invertedai:api",
+        "@boost//:beast",
+        "@opencv",
+    ],
+)

--- a/invertedai_cpp/examples/BUILD
+++ b/invertedai_cpp/examples/BUILD
@@ -66,6 +66,9 @@ cc_binary(
     srcs = ["drive_tests.cc"],
     data = [
         "drive_body.json",
+        "initialize_body.json",
+        "initialize_sampling_with_types.json",
+        "initialize_with_states_and_attributes.json",
     ],
     deps = [
         "//invertedai:api",

--- a/invertedai_cpp/examples/drive_body.json
+++ b/invertedai_cpp/examples/drive_body.json
@@ -14,6 +14,18 @@
             7.58
         ]
     ],
+    "agent_attributes": [
+        [
+            5.10,
+            4.65,
+            1.23
+        ],
+        [
+            4.79,
+            4.58,
+            1.17
+        ]
+    ],
     "recurrent_states": null,
     "get_birdview": true,
     "get_infractions": true,

--- a/invertedai_cpp/examples/drive_tests.cc
+++ b/invertedai_cpp/examples/drive_tests.cc
@@ -1,0 +1,73 @@
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+#include <opencv2/highgui.hpp>
+#include <opencv2/imgcodecs.hpp>
+#include <opencv2/imgproc.hpp>
+
+#include "../invertedai/api.h"
+
+using tcp = net::ip::tcp;    // from <boost/asio/ip/tcp.hpp>
+using json = nlohmann::json; // from <json.hpp>
+
+int main(int argc, char **argv) {
+  // Set up drive scenarios from initialize
+  const char* tests[] =
+  {
+    "examples/initialize_body.json",
+    "examples/initialize_with_states_and_attributes.json",
+    "examples/initialize_sampling_with_types.json"
+  };
+
+   try {
+    const int timestep = std::stoi(argv[1]);
+    const std::string api_key(argv[2]);
+
+    net::io_context ioc;
+    ssl::context ctx(ssl::context::tlsv12_client);
+    // configure connection setting
+    invertedai::Session session(ioc, ctx);
+    session.set_api_key(api_key);
+    session.connect();
+    int i = 0;
+    for (const char *test : tests) {
+        invertedai::InitializeRequest init_req(invertedai::read_file(test));
+        invertedai::InitializeResponse init_res = invertedai::initialize(init_req, &session);
+        auto image = cv::imdecode(init_res.birdview(), cv::IMREAD_COLOR);
+        cv::cvtColor(image, image, cv::COLOR_BGR2RGB);
+        int frame_width = image.rows;
+        int frame_height = image.cols;
+        std::string drive_video_name = "drive_test_" + std::to_string(i) + ".avi";
+        cv::VideoWriter video(
+            drive_video_name,
+            cv::VideoWriter::fourcc('M', 'J', 'P', 'G'),
+            10,
+            cv::Size(frame_width, frame_height)
+        );
+        i += 1;
+        invertedai::DriveRequest drive_req(invertedai::read_file("examples/drive_body.json"));
+        drive_req.set_location(init_req.location());
+        drive_req.update(init_res);
+
+        for (int t = 0; t < timestep; t++) {
+          // step the simulation by driving the agents
+          invertedai::DriveResponse drive_res = invertedai::drive(drive_req, &session);
+          // use opencv to decode and save the bird's eye view image of the
+          // simulation
+          auto image = cv::imdecode(drive_res.birdview(), cv::IMREAD_COLOR);
+          cv::cvtColor(image, image, cv::COLOR_BGR2RGB);
+          video.write(image);
+          drive_req.update(drive_res);
+          std::cout << "Remaining iterations: " << timestep - t << std::endl;
+        }
+        video.release();
+    }
+  } catch (std::exception const &e) {
+    std::cerr << "Error: " << e.what() << std::endl;
+    return EXIT_FAILURE;
+  }
+  return EXIT_SUCCESS;
+}

--- a/invertedai_cpp/examples/initialize_body.json
+++ b/invertedai_cpp/examples/initialize_body.json
@@ -4,8 +4,8 @@
     "states_history": null,
     "agent_attributes": null,
     "traffic_light_state_history": null,
-    "get_birdview": false,
-    "get_infractions": false,
+    "get_birdview": true,
+    "get_infractions": true,
     "random_seed": null,
     "location_of_interest": null
 }

--- a/invertedai_cpp/examples/initialize_body.json
+++ b/invertedai_cpp/examples/initialize_body.json
@@ -2,7 +2,7 @@
     "location": "iai:ubc_roundabout",
     "num_agents_to_spawn": 10,
     "states_history": null,
-    "agent_attributes": null,
+    "agent_attributes": [[], []],
     "traffic_light_state_history": null,
     "get_birdview": false,
     "get_infractions": false,

--- a/invertedai_cpp/examples/initialize_body.json
+++ b/invertedai_cpp/examples/initialize_body.json
@@ -1,8 +1,8 @@
 {
-    "location": "iai:ubc_roundabout",
+    "location": "carla:Town03",
     "num_agents_to_spawn": 10,
     "states_history": null,
-    "agent_attributes": [[], []],
+    "agent_attributes": null,
     "traffic_light_state_history": null,
     "get_birdview": false,
     "get_infractions": false,

--- a/invertedai_cpp/examples/initialize_sampling_with_types.json
+++ b/invertedai_cpp/examples/initialize_sampling_with_types.json
@@ -1,0 +1,17 @@
+{
+    "location": "carla:Town04",
+    "num_agents_to_spawn": 10,
+    "states_history": null,
+    "agent_attributes": [
+        ["car"],
+        ["pedestrian"],
+        [],
+        ["pedestrian"],
+        ["pedestrian"]
+    ],
+    "traffic_light_state_history": null,
+    "get_birdview": true,
+    "get_infractions": true,
+    "random_seed": null,
+    "location_of_interest": null
+}

--- a/invertedai_cpp/examples/initialize_tests.cc
+++ b/invertedai_cpp/examples/initialize_tests.cc
@@ -1,0 +1,67 @@
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+#include <opencv2/highgui.hpp>
+#include <opencv2/imgcodecs.hpp>
+#include <opencv2/imgproc.hpp>
+
+#include "../invertedai/api.h"
+
+using tcp = net::ip::tcp;    // from <boost/asio/ip/tcp.hpp>
+using json = nlohmann::json; // from <json.hpp>
+
+int main(int argc, char **argv) {
+  try {
+    const std::string location(argv[1]);
+    const int agent_num = std::stoi(argv[2]);
+    const std::string api_key(argv[3]);
+
+    net::io_context ioc;
+    ssl::context ctx(ssl::context::tlsv12_client);
+    // configure connection setting
+    invertedai::Session session(ioc, ctx);
+    session.set_api_key(api_key);
+    session.connect();
+
+    // construct request for getting information about the location
+    invertedai::LocationInfoRequest loc_info_req(invertedai::read_file("examples/location_info_body.json"));
+    loc_info_req.set_location(location);
+
+    // get response of location information
+    invertedai::LocationInfoResponse loc_info_res = invertedai::location_info(loc_info_req, &session);
+
+    // use opencv to decode and save the bird's eye view image of the simulation
+    auto image = cv::imdecode(loc_info_res.birdview_image(), cv::IMREAD_COLOR);
+    cv::cvtColor(image, image, cv::COLOR_BGR2RGB);
+    int frame_width = image.rows;
+    int frame_height = image.cols;
+    cv::VideoWriter video(
+      "initialize_test_run.avi",
+      cv::VideoWriter::fourcc('M', 'J', 'P', 'G'),
+      10,
+      cv::Size(frame_width, frame_height)
+    );
+
+    // construct request for initializing the simulation (placing NPCs on the
+    // map)
+    invertedai::InitializeRequest init_req(invertedai::read_file("examples/initialize_with_states_and_attributes.json"));
+    // set the location
+    init_req.set_location(location);
+    // set the number of agents
+    init_req.set_num_agents_to_spawn(agent_num);
+    // get the response of simulation initialization
+    invertedai::InitializeResponse init_res = invertedai::initialize(init_req, &session);
+
+    image = cv::imdecode(init_res.birdview(), cv::IMREAD_COLOR);
+    cv::cvtColor(image, image, cv::COLOR_BGR2RGB);
+    video.write(image);
+    video.release();
+  } catch (std::exception const &e) {
+    std::cerr << "Error: " << e.what() << std::endl;
+    return EXIT_FAILURE;
+  }
+  return EXIT_SUCCESS;
+}

--- a/invertedai_cpp/examples/initialize_tests.cc
+++ b/invertedai_cpp/examples/initialize_tests.cc
@@ -3,7 +3,7 @@
 #include <iostream>
 #include <sstream>
 #include <string>
-
+#include <vector>
 #include <opencv2/highgui.hpp>
 #include <opencv2/imgcodecs.hpp>
 #include <opencv2/imgproc.hpp>
@@ -14,10 +14,15 @@ using tcp = net::ip::tcp;    // from <boost/asio/ip/tcp.hpp>
 using json = nlohmann::json; // from <json.hpp>
 
 int main(int argc, char **argv) {
+  // list of test scenarios to run
+  const char* tests[] =
+  {
+    "examples/initialize_with_states_and_attributes.json",
+    "examples/initialize_sampling_with_types.json"
+  };
+
   try {
-    const std::string location(argv[1]);
-    const int agent_num = std::stoi(argv[2]);
-    const std::string api_key(argv[3]);
+    const std::string api_key(argv[0]);
 
     net::io_context ioc;
     ssl::context ctx(ssl::context::tlsv12_client);
@@ -25,40 +30,16 @@ int main(int argc, char **argv) {
     invertedai::Session session(ioc, ctx);
     session.set_api_key(api_key);
     session.connect();
-
-    // construct request for getting information about the location
-    invertedai::LocationInfoRequest loc_info_req(invertedai::read_file("examples/location_info_body.json"));
-    loc_info_req.set_location(location);
-
-    // get response of location information
-    invertedai::LocationInfoResponse loc_info_res = invertedai::location_info(loc_info_req, &session);
-
-    // use opencv to decode and save the bird's eye view image of the simulation
-    auto image = cv::imdecode(loc_info_res.birdview_image(), cv::IMREAD_COLOR);
-    cv::cvtColor(image, image, cv::COLOR_BGR2RGB);
-    int frame_width = image.rows;
-    int frame_height = image.cols;
-    cv::VideoWriter video(
-      "initialize_test_run.avi",
-      cv::VideoWriter::fourcc('M', 'J', 'P', 'G'),
-      10,
-      cv::Size(frame_width, frame_height)
-    );
-
-    // construct request for initializing the simulation (placing NPCs on the
-    // map)
-    invertedai::InitializeRequest init_req(invertedai::read_file("examples/initialize_with_states_and_attributes.json"));
-    // set the location
-    init_req.set_location(location);
-    // set the number of agents
-    init_req.set_num_agents_to_spawn(agent_num);
-    // get the response of simulation initialization
-    invertedai::InitializeResponse init_res = invertedai::initialize(init_req, &session);
-
-    image = cv::imdecode(init_res.birdview(), cv::IMREAD_COLOR);
-    cv::cvtColor(image, image, cv::COLOR_BGR2RGB);
-    video.write(image);
-    video.release();
+    int i = 0;
+    for (const char *test : tests) {
+        invertedai::InitializeRequest init_req(invertedai::read_file(test));
+        invertedai::InitializeResponse init_res = invertedai::initialize(init_req, &session);
+        auto image = cv::imdecode(init_res.birdview(), cv::IMREAD_COLOR);
+        cv::cvtColor(image, image, cv::COLOR_BGR2RGB);
+        std::string img_name = "initialize_test_" + std::to_string(i) + ".png";
+        cv::imwrite(img_name, image);
+        i += 1;
+    }
   } catch (std::exception const &e) {
     std::cerr << "Error: " << e.what() << std::endl;
     return EXIT_FAILURE;

--- a/invertedai_cpp/examples/initialize_tests.cc
+++ b/invertedai_cpp/examples/initialize_tests.cc
@@ -17,12 +17,13 @@ int main(int argc, char **argv) {
   // list of test scenarios to run
   const char* tests[] =
   {
+    "examples/initialize_body.json",
     "examples/initialize_with_states_and_attributes.json",
     "examples/initialize_sampling_with_types.json"
   };
 
   try {
-    const std::string api_key(argv[0]);
+    const std::string api_key(argv[1]);
 
     net::io_context ioc;
     ssl::context ctx(ssl::context::tlsv12_client);

--- a/invertedai_cpp/examples/initialize_with_states_and_attributes.json
+++ b/invertedai_cpp/examples/initialize_with_states_and_attributes.json
@@ -1,0 +1,81 @@
+{
+    "location": "canada:ubc_roundabout",
+    "num_agents_to_spawn": 10,
+    "states_history": [
+        [
+            [
+                -11.38,
+                25.95,
+                -1.09,
+                9.42
+            ],
+            [
+                48.3,
+                13.65,
+                0.11,
+                0.95
+            ],
+            [
+                -5.81,
+                -37.0,
+                0.15,
+                0.47
+            ],
+            [
+                -11.75,
+                24.38,
+                -2.29,
+                0.98
+            ],
+            [
+                36.69,
+                6.91,
+                -3.07,
+                6.18
+            ]
+        ]
+    ],
+    "agent_attributes": [
+        [
+            5.15,
+            2.43,
+            1.96,
+            "car"
+        ],
+        [
+            1.2,
+            1.51,
+            null,
+            "pedestrian"
+        ],
+        [
+            5.11,
+            2.17,
+            1.94,
+            "car"
+        ],
+        [
+            1.16,
+            1.41,
+            null,
+            "pedestrian"
+        ],
+        [
+            5.18,
+            2.22,
+            1.97,
+            "car"
+        ],
+        [
+
+        ],
+        [
+            "pedestrian"
+        ]
+    ],
+    "traffic_light_state_history": null,
+    "get_birdview": true,
+    "get_infractions": true,
+    "random_seed": null,
+    "location_of_interest": null
+}

--- a/invertedai_cpp/invertedai/BUILD
+++ b/invertedai_cpp/invertedai/BUILD
@@ -4,6 +4,9 @@ cc_library(
     name = "data_utils",
     srcs = ["data_utils.cc"],
     hdrs = ["data_utils.h"],
+    deps = [
+    "//invertedai/externals:json",
+    ],
 )
 
 cc_library(

--- a/invertedai_cpp/invertedai/blame_request.cc
+++ b/invertedai_cpp/invertedai/blame_request.cc
@@ -1,6 +1,7 @@
 #include "blame_request.h"
 
 #include "externals/json.hpp"
+#include <iostream>
 
 using json = nlohmann::json;
 
@@ -28,12 +29,8 @@ BlameRequest::BlameRequest(const std::string &body_str) {
   }
   this->agent_attributes_.clear();
   for (const auto &element : this->body_json_["agent_attributes"]) {
-    AgentAttributes agent_attribute = {
-      element[0], 
-      element[1], 
-      element[2], 
-      element[3]
-    };
+    AgentAttributes agent_attribute(element);
+    agent_attribute.printFields();
     this->agent_attributes_.push_back(agent_attribute);
   }
   if (this->body_json_["traffic_light_state_history"].is_null()) {
@@ -85,12 +82,7 @@ void BlameRequest::refresh_body_json_() {
   }
   this->body_json_["agent_attributes"].clear();
   for (const AgentAttributes &agent_attribute : this->agent_attributes_) {
-    json element = {
-      agent_attribute.length, 
-      agent_attribute.width,
-      agent_attribute.rear_axis_offset,
-      agent_attribute.agent_type
-    };
+    json element = agent_attribute.toJson();
     this->body_json_["agent_attributes"].push_back(element);
   }
   if (this->traffic_light_state_history_.has_value()) {

--- a/invertedai_cpp/invertedai/blame_request.cc
+++ b/invertedai_cpp/invertedai/blame_request.cc
@@ -30,7 +30,6 @@ BlameRequest::BlameRequest(const std::string &body_str) {
   this->agent_attributes_.clear();
   for (const auto &element : this->body_json_["agent_attributes"]) {
     AgentAttributes agent_attribute(element);
-    agent_attribute.printFields();
     this->agent_attributes_.push_back(agent_attribute);
   }
   if (this->body_json_["traffic_light_state_history"].is_null()) {

--- a/invertedai_cpp/invertedai/drive_request.cc
+++ b/invertedai_cpp/invertedai/drive_request.cc
@@ -23,7 +23,6 @@ DriveRequest::DriveRequest(const std::string &body_str) {
   this->agent_attributes_.clear();
   for (const auto &element : this->body_json_["agent_attributes"]) {
     AgentAttributes agent_attribute(element);
-    agent_attribute.printFields();
     this->agent_attributes_.push_back(agent_attribute);
   }
   this->recurrent_states_.clear();

--- a/invertedai_cpp/invertedai/drive_request.cc
+++ b/invertedai_cpp/invertedai/drive_request.cc
@@ -1,5 +1,5 @@
 #include "drive_request.h"
-
+#include <iostream>
 #include "externals/json.hpp"
 
 using json = nlohmann::json;
@@ -19,6 +19,12 @@ DriveRequest::DriveRequest(const std::string &body_str) {
       element[3]
     };
     this->agent_states_.push_back(agent_state);
+  }
+  this->agent_attributes_.clear();
+  for (const auto &element : this->body_json_["agent_attributes"]) {
+    AgentAttributes agent_attribute(element);
+    agent_attribute.printFields();
+    this->agent_attributes_.push_back(agent_attribute);
   }
   this->recurrent_states_.clear();
   for (const auto &element : this->body_json_["recurrent_states"]) {
@@ -71,12 +77,7 @@ void DriveRequest::refresh_body_json_() {
   }
   this->body_json_["agent_attributes"].clear();
   for (const AgentAttributes &agent_attribute : this->agent_attributes_) {
-    json element = {
-      agent_attribute.length, 
-      agent_attribute.width,
-      agent_attribute.rear_axis_offset,
-      agent_attribute.agent_type
-    };
+    json element = agent_attribute.toJson();
     this->body_json_["agent_attributes"].push_back(element);
   }
   this->body_json_["recurrent_states"].clear();

--- a/invertedai_cpp/invertedai/initialize_request.cc
+++ b/invertedai_cpp/invertedai/initialize_request.cc
@@ -1,5 +1,5 @@
 #include "initialize_request.h"
-
+#include <iostream>
 using json = nlohmann::json;
 
 namespace invertedai {
@@ -23,12 +23,8 @@ InitializeRequest::InitializeRequest(const std::string &body_str) {
   }
   this->agent_attributes_.clear();
   for (const auto &element : this->body_json_["agent_attributes"]) {
-    AgentAttributes agent_attribute = {
-      element[0], 
-      element[1], 
-      element[2], 
-      element[3]
-    };
+    AgentAttributes agent_attribute(element);
+    agent_attribute.printFields();
     this->agent_attributes_.push_back(agent_attribute);
   }
   this->traffic_light_state_history_.clear();
@@ -83,12 +79,7 @@ void InitializeRequest::refresh_body_json_() {
   }
   this->body_json_["agent_attributes"].clear();
   for (const AgentAttributes &agent_attribute : this->agent_attributes_) {
-    json element = {
-      agent_attribute.length, 
-      agent_attribute.width,
-      agent_attribute.rear_axis_offset,
-      agent_attribute.agent_type
-    };
+    json element = agent_attribute.toJson();
     this->body_json_["agent_attributes"].push_back(element);
   }
   this->body_json_["traffic_light_state_history"].clear();

--- a/invertedai_cpp/invertedai/initialize_request.cc
+++ b/invertedai_cpp/invertedai/initialize_request.cc
@@ -24,7 +24,6 @@ InitializeRequest::InitializeRequest(const std::string &body_str) {
   this->agent_attributes_.clear();
   for (const auto &element : this->body_json_["agent_attributes"]) {
     AgentAttributes agent_attribute(element);
-    agent_attribute.printFields();
     this->agent_attributes_.push_back(agent_attribute);
   }
   this->traffic_light_state_history_.clear();

--- a/invertedai_cpp/invertedai/initialize_response.cc
+++ b/invertedai_cpp/invertedai/initialize_response.cc
@@ -1,5 +1,5 @@
 #include "initialize_response.h"
-
+#include <iostream>
 using json = nlohmann::json;
 
 namespace invertedai {
@@ -19,12 +19,8 @@ InitializeResponse::InitializeResponse(const std::string &body_str) {
   }
   this->agent_attributes_.clear();
   for (const auto &element : body_json_["agent_attributes"]) {
-    AgentAttributes agent_attribute = {
-      element[0], 
-      element[1], 
-      element[2], 
-      element[3]
-    };
+    AgentAttributes agent_attribute(element);
+    agent_attribute.printFields();
     this->agent_attributes_.push_back(agent_attribute);
   }
   this->recurrent_states_.clear();
@@ -66,12 +62,7 @@ void InitializeResponse::refresh_body_json_() {
   }
   this->body_json_["agent_attributes"].clear();
   for (const AgentAttributes &agent_attribute : this->agent_attributes_) {
-    json element = {
-      agent_attribute.length, 
-      agent_attribute.width,
-      agent_attribute.rear_axis_offset,
-      agent_attribute.agent_type
-    };
+    json element = agent_attribute.toJson();
     this->body_json_["agent_attributes"].push_back(element);
   }
   this->body_json_["recurrent_states"].clear();

--- a/invertedai_cpp/invertedai/initialize_response.cc
+++ b/invertedai_cpp/invertedai/initialize_response.cc
@@ -20,7 +20,6 @@ InitializeResponse::InitializeResponse(const std::string &body_str) {
   this->agent_attributes_.clear();
   for (const auto &element : body_json_["agent_attributes"]) {
     AgentAttributes agent_attribute(element);
-    agent_attribute.printFields();
     this->agent_attributes_.push_back(agent_attribute);
   }
   this->recurrent_states_.clear();

--- a/invertedai_cpp/run_all_tests.sh
+++ b/invertedai_cpp/run_all_tests.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+export IAI_DEV=1
+
+bazel build //examples:drive_tests
+bazel build //examples:initialize_tests
+
+./bazel-bin/examples/initialize_tests "EFGHTOKENABCD"
+./bazel-bin/examples/drive_tests 30 "EFGHTOKENABCD"

--- a/tests/test_drive.py
+++ b/tests/test_drive.py
@@ -8,6 +8,7 @@ from invertedai.api.location import location_info
 from invertedai.api.light import light
 from invertedai.error import InvalidRequestError
 
+
 def recurrent_states_helper(states_to_extend):
     result = [0.0] * 128
     result.extend(states_to_extend)
@@ -58,8 +59,10 @@ positive_tests = [
       dict(agent_type='car')],
      False, None),
 ]
+
+# Notice parameterization in direct drive flows are different
 negative_tests = [
-     ("carla:Town03",
+    ("carla:Town03",
      [dict(center=dict(x=-21.2, y=-17.11), orientation=4.54, speed=1.8),
       dict(center=dict(x=-5.81, y=-49.47), orientation=1.62, speed=11.4)],
      [dict(length=0.97, agent_type="pedestrian"),
@@ -90,6 +93,7 @@ negative_tests = [
              [5.810295104980469, -49.47068786621094, 1.5232856273651123, 11.404326438903809]))],
      False),
 ]
+
 
 def run_initialize_drive_flow(location, states_history, agent_attributes, get_infractions, agent_count,
                               simulation_length: int = 20):
@@ -137,15 +141,16 @@ def run_direct_drive(location, agent_states, agent_attributes, recurrent_states,
     )
     assert isinstance(drive_response,
                       DriveResponse) and drive_response.agent_states is not None and drive_response.recurrent_states is not None
-    
 
-@pytest.mark.parametrize("location, states_history, agent_attributes, get_infractions, agent_count", negative_tests)
-def test_negative(location, states_history, agent_attributes, get_infractions, agent_count,
-                  simulation_length: int = 20):
+
+@pytest.mark.parametrize("location, agent_states, agent_attributes, recurrent_states, get_infractions", negative_tests)
+def test_negative(location, agent_states, agent_attributes, recurrent_states, get_infractions):
     with pytest.raises(InvalidRequestError):
-        run_direct_drive(location, states_history, agent_attributes, get_infractions, agent_count)
+        run_direct_drive(location, agent_states, agent_attributes, recurrent_states, get_infractions)
+
 
 @pytest.mark.parametrize("location, states_history, agent_attributes, get_infractions, agent_count", positive_tests)
 def test_postivie(location, states_history, agent_attributes, get_infractions, agent_count,
                   simulation_length: int = 20):
-    run_initialize_drive_flow(location, states_history, agent_attributes, get_infractions, agent_count)
+    run_initialize_drive_flow(location, states_history, agent_attributes, get_infractions, agent_count,
+                              simulation_length)

--- a/tests/test_initialize.py
+++ b/tests/test_initialize.py
@@ -157,12 +157,13 @@ def run_initialize(location, states_history, agent_attributes, get_infractions, 
     assert isinstance(response,
                       InitializeResponse) and response.agent_attributes is not None and response.agent_states is not None
 
+
 @pytest.mark.parametrize("location, states_history, agent_attributes, get_infractions, agent_count", negative_tests)
 def test_negative(location, states_history, agent_attributes, get_infractions, agent_count):
     with pytest.raises(InvalidRequestError):
         run_initialize(location, states_history, agent_attributes, get_infractions, agent_count)
 
+
 @pytest.mark.parametrize("location, states_history, agent_attributes, get_infractions, agent_count", positive_tests)
 def test_positive(location, states_history, agent_attributes, get_infractions, agent_count):
     run_initialize(location, states_history, agent_attributes, get_infractions, agent_count)
-  


### PR DESCRIPTION
Python client:
- Added tests to call drive directly in addition to initialize-drive flows
- Request validation consistency between initialize and drive tested on client side

C++ client:
- Agent Attribute data model update, rear_axis_offset and agent_type not always required
- Code updates to support calls other than null states & attributes
- Adding more complete integration tests for drive and initialzie (WIP)