### PR TITLE
updated all the swaggerhub links to point at the most up-to-date docs

### DIFF
--- a/docs/source/cppapi/index.md
+++ b/docs/source/cppapi/index.md
@@ -1,6 +1,6 @@
 # C++ SDK
 
-This page is a detailed reference for the C++ library. The underlying [REST API](https://app.swaggerhub.com/apis-docs/swaggerhub59/Inverted-AI/0.0.2) can also be
+This page is a detailed reference for the C++ library. The underlying [REST API](https://app.swaggerhub.com/apis/InvertedAI/InvertedAI/) can also be
 accessed directly. Below are the key functions of the library, along with some common utilities.
 
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -10,7 +10,7 @@ hide-toc: true
 [github-badge]: https://badgen.net/badge/icon/github?icon=github&label
 [github-link]: https://github.com/inverted-ai/invertedai/
 [colab-link]: https://colab.research.google.com/github/inverted-ai/invertedai/blob/develop/examples/IAI_demo.ipynb
-[rest-link]: https://app.swaggerhub.com/apis/swaggerhub59/Inverted-AI
+[rest-link]: https://app.swaggerhub.com/apis/InvertedAI/InvertedAI/
 [examples-link]: https://github.com/inverted-ai/invertedai/tree/master/examples
 [![GitHub][github-badge]][github-link]
 [![PyPI][pypi-badge]][pypi-link]
@@ -38,7 +38,7 @@ self
 userguide
 pythonapi/index
 cppapi/index
-REST API <https://app.swaggerhub.com/apis/swaggerhub59/Inverted-AI>
+REST API <https://app.swaggerhub.com/apis/InvertedAI/InvertedAI/>
 pythonapi/pyexamples
 ```
 

--- a/docs/source/pythonapi/index.md
+++ b/docs/source/pythonapi/index.md
@@ -1,6 +1,6 @@
 # Python SDK
 
-This page is a detailed reference for the Python library. The underlying [REST API](https://app.swaggerhub.com/apis-docs/swaggerhub59/Inverted-AI/0.0.2) can also be
+This page is a detailed reference for the Python library. The underlying [REST API](https://app.swaggerhub.com/apis/InvertedAI/InvertedAI/) can also be
 accessed directly. Below are the key functions of the library, along with some common utilities.
 
 

--- a/docs/source/userguide.md
+++ b/docs/source/userguide.md
@@ -1,5 +1,5 @@
 [examples-link]: https://github.com/inverted-ai/invertedai/tree/master/examples
-[rest-link]: https://app.swaggerhub.com/apis/swaggerhub59/Inverted-AI
+[rest-link]: https://app.swaggerhub.com/apis/InvertedAI/InvertedAI/
 # User Guide
 
 Inverted AI API provides a service that controls non-playable characters (NPCs) in driving simulations. The two main


### PR DESCRIPTION
The documentation currently points at the old rest api documentation, https://app.swaggerhub.com/apis/swaggerhub59/Inverted-AI, instead of the more official https://app.swaggerhub.com/apis/InvertedAI/InvertedAI/ which includes updated docs for waypoint drive and pedestrians.

this PR also matches the rest API links on the website.