### PR TITLE
Make pygame and cv2 dependency optional

### DIFF
--- a/examples/area_drive/area_drive.py
+++ b/examples/area_drive/area_drive.py
@@ -1,8 +1,10 @@
 from typing import Tuple, Optional, List
-from pygame.math import Vector2
 from dataclasses import dataclass
 import numpy as np
-import pygame
+try:
+    import pygame
+except ImportError:
+    pygame = None
 import asyncio
 import time
 import random
@@ -106,11 +108,11 @@ class AreaDriver:
         )
 
         self.boundary = Rectangle(
-            Vector2(
+            (
                 self.cfg.area_center[0] - (self.area_fov / 2),
                 self.cfg.area_center[1] - (self.area_fov / 2)
             ),
-            Vector2((self.area_fov, self.area_fov)),
+            (self.area_fov, self.area_fov),
             convertors=(self.convert_to_pygame_coords, self.convert_to_pygame_scales)
         )
 

--- a/examples/area_drive/car.py
+++ b/examples/area_drive/car.py
@@ -1,6 +1,8 @@
 from typing import Optional
-import pygame
-from pygame.math import Vector2
+try:
+    import pygame
+except ImportError:
+    pygame = None
 from pydantic import validate_call
 from invertedai.common import AgentState, AgentAttributes, RecurrentState
 from collections import deque
@@ -48,8 +50,8 @@ class Car:
 
     def fov_range(self):
         return Rectangle(
-            Vector2(self.position.x-(self.fov/2), self.position.y-(self.fov/2)),
-            Vector2((self.fov, self.fov)),
+            (self.position.x-(self.fov/2), self.position.y-(self.fov/2)),
+            ((self.fov, self.fov)),
             convertors=(self.convertor_coords, self.convertor_scales)
         )
 

--- a/examples/area_drive/regions.py
+++ b/examples/area_drive/regions.py
@@ -1,4 +1,3 @@
-from pygame.math import Vector2
 from area_drive.utils import Rectangle, RE_INITIALIZATION_PERIOD, DEBUG, AGENT_FOV
 from typing import List, Optional, Callable
 from random import randint
@@ -141,11 +140,11 @@ class QuadTree:
         self.buffer_length = AGENT_FOV
 
         self.boundary_buffer = Rectangle(
-            Vector2(
-                self.boundary.position.x-self.buffer_length,
-                self.boundary.position.y-self.buffer_length
+            (
+                self.boundary.position[0]-self.buffer_length,
+                self.boundary.position[1]-self.buffer_length
             ),
-            Vector2(self.boundary.scale[0]+self.buffer_length*2,self.boundary.scale[1]+self.buffer_length*2),
+            (self.boundary.scale[0]+self.buffer_length*2,self.boundary.scale[1]+self.buffer_length*2),
             convertors=self.convertors
         )
         self.region = Region(boundary=self.boundary_buffer, cfg=cfg)
@@ -155,7 +154,7 @@ class QuadTree:
         parent = self.boundary
 
         boundary_nw = Rectangle(
-            Vector2(
+            (
                 parent.position.x,
                 parent.position.y
             ),
@@ -163,7 +162,7 @@ class QuadTree:
             convertors=self.convertors
         )
         boundary_ne = Rectangle(
-            Vector2(
+            (
                 parent.position.x + parent.scale.x / 2,
                 parent.position.y
             ),
@@ -171,7 +170,7 @@ class QuadTree:
             convertors=self.convertors
         )
         boundary_sw = Rectangle(
-            Vector2(
+            (
                 parent.position.x,
                 parent.position.y + parent.scale.y / 2
             ),
@@ -179,7 +178,7 @@ class QuadTree:
             convertors=self.convertors
         )
         boundary_se = Rectangle(
-            Vector2(
+            (
                 parent.position.x + parent.scale.x / 2,
                 parent.position.y + parent.scale.y / 2
             ),

--- a/examples/area_drive/utils.py
+++ b/examples/area_drive/utils.py
@@ -1,4 +1,7 @@
-import pygame
+try:
+    import pygame
+except ImportError:
+    pygame=None
 import math
 from invertedai.common import Point
 from typing import Tuple

--- a/examples/large_map_example.py
+++ b/examples/large_map_example.py
@@ -5,7 +5,6 @@ import invertedai as iai
 from area_drive.area_drive import AreaDriver, AreaDriverConfig
 
 import argparse
-import pygame
 from tqdm import tqdm
 import matplotlib.pyplot as plt
 import time

--- a/invertedai/common.py
+++ b/invertedai/common.py
@@ -2,7 +2,9 @@ from typing import List, Optional, Dict
 from enum import Enum
 from pydantic import BaseModel, model_validator
 import math
-
+from PIL import Image as PImage
+import numpy as np
+import io
 import invertedai as iai
 from invertedai.error import InvalidInputType, InvalidInput
 
@@ -78,19 +80,14 @@ class Image(BaseModel):
     def decode(self):
         """
         Decode and return the image.
-        Requires numpy and cv2 to be available, otherwise raises `ImportError`.
         """
-        try:
-            import numpy as np
-            import cv2
-        except ImportError as e:
-            iai.logger.error(
-                "Decoding images requires numpy and cv2, which were not found."
-            )
-            raise e
-        array = np.array(self.encoded_image, dtype=np.uint8)
-        image = cv2.imdecode(array, cv2.IMREAD_COLOR)
-        return image
+        self.encoded_image = bytes(self.encoded_image)
+        img_stream = io.BytesIO(self.encoded_image)
+        img = PImage.open(img_stream)
+        img_array = np.array(img)
+        img_array = img_array[:, :, ::-1]
+        return img_array
+
 
     @classmethod
     def fromval(cls, val):

--- a/invertedai/common.py
+++ b/invertedai/common.py
@@ -96,11 +96,10 @@ class Image(BaseModel):
     def decode_and_save(self, path):
         """
         Decode the image and save it to the specified path.
-        Requires numpy and cv2 to be available, otherwise raises `ImportError`.
         """
         image = self.decode()
-        import cv2
-        cv2.imwrite(path, cv2.cvtColor(image, cv2.COLOR_BGR2RGB))
+        image_pil = PImage.fromarray(image)
+        image_pil.save(path)
 
 
 class TrafficLightState(str, Enum):

--- a/poetry.lock
+++ b/poetry.lock
@@ -3799,4 +3799,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<=3.12"
-content-hash = "de84cb2224bac2e8ef8be413083486eeca6c39c1035c65c5ad80c15a5e7e57fc"
+content-hash = "9abe80d5b475cafeb5e67c42b865a623fbdc198e269eb45f908cd5474147dba7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,10 +15,9 @@ requests = "^2.28.1"
 pydantic = "^2.5.3"
 matplotlib = "^3.6.2"
 tqdm = "^4.65.0"
+numpy = "^1.24.4"
 
 [tool.poetry.group.dev.dependencies]
-numpy = "^1.17.0"
-matplotlib = ">=3.6.2"
 ipython = "^7.34"
 ipywidgets = "^8.0.2"
 carla = "^0.9.13"


### PR DESCRIPTION
- Use PIL instead of opencv to decode the encoded bvs to avoid import error when opencv is not installed
- Use Tuple instead of pygame's Vector2 in area_drive to make pygame also an optional dependency. This will pave the way for us to consider packaging the area_drive folder inside invertedai.

I was able to run the ` large_map_example.py` example in a minimum virtualenv with only `invertedai` installed and generating the bv.

@adscib  Let me know what do you think about this.