### PR TITLE
Add SimulationManager.form_regions() with RegionsConfig

### DIFF
--- a/examples/simulation_manager_cosimulation_minimal_example.py
+++ b/examples/simulation_manager_cosimulation_minimal_example.py
@@ -13,6 +13,7 @@ from invertedai import (
     get_default_agent_properties,
 )
 from invertedai import LogWriterConfig
+from invertedai import RegionsConfig
 import matplotlib.pyplot as plt
 import os
 import uuid
@@ -59,11 +60,12 @@ ego_props = ego_waypoint_manager.update(
     agent_properties=ego_props
 )
 ##########################################################################################################
-regions = iai.get_regions_default(
-    agent_count_dict = {AgentType.car: NUM_AGENTS}, 
-    location = LOCATION, 
-    map_center=tuple([location_info_response.map_center.x, location_info_response.map_center.y])
+regions_config = RegionsConfig(
+    location=LOCATION,
+    agent_count_dict={AgentType.car: NUM_AGENTS},
+    map_center=(location_info_response.map_center.x, location_info_response.map_center.y),
 )
+regions = simulation_manager.form_regions(regions_config)
 ego_agent_ids = [f"ego_agent_{i}_{str(uuid.uuid4())[:8]}" for i in range(NUM_EGO_AGENTS)]
 external_agent_data = {
     ego_agent_ids[i]: AgentData(

--- a/examples/simulation_manager_minimal_example.py
+++ b/examples/simulation_manager_minimal_example.py
@@ -4,6 +4,7 @@ from invertedai import WaypointManagerConfig
 from invertedai import SimulationManager
 from invertedai import ScenePlotterConfig
 from invertedai import LogWriterConfig
+from invertedai import RegionsConfig
 import matplotlib.pyplot as plt
 import os
 
@@ -22,7 +23,8 @@ scene_plotter_cfg = ScenePlotterConfig(location=LOCATION, location_info_response
 waypoint_cfg = WaypointManagerConfig(lanelet_map = location_info_response.get_lanelet_map())
 log_cfg = LogWriterConfig(log_path="keyed_minimal_example_log.json",location=LOCATION, location_info_response=location_info_response)
 simulation_manager = SimulationManager(scene_plotter_cfg=scene_plotter_cfg, waypoint_cfg=waypoint_cfg, log_writer_cfg=log_cfg)
-regions = iai.get_regions_default(agent_count_dict = {AgentType.car: NUM_AGENTS}, location = LOCATION)
+regions_config = RegionsConfig(location=LOCATION, agent_count_dict={AgentType.car: NUM_AGENTS})
+regions = simulation_manager.form_regions(regions_config)
 response = simulation_manager.initialize(location=LOCATION, regions=regions)
 print("initialized agents with ids ", simulation_manager.get_agent_ids())
 rendered_static_map = location_info_response.birdview_image.decode()

--- a/invertedai/__init__.py
+++ b/invertedai/__init__.py
@@ -41,6 +41,7 @@ from invertedai.large.initialize import (
     get_number_of_agents_per_region_by_drivable_area,
     get_regions_default,
     large_initialize,
+    RegionsConfig,
 )
 from invertedai.large.drive import large_drive
 from invertedai.large.common import Region
@@ -158,6 +159,7 @@ __all__ = [
     "get_regions_in_grid",
     "get_number_of_agents_per_region_by_drivable_area",
     "Region",
+    "RegionsConfig",
     # Helpers
     "WaypointManager",
     "WaypointManagerConfig",

--- a/invertedai/helpers/simulation_manager.py
+++ b/invertedai/helpers/simulation_manager.py
@@ -62,9 +62,9 @@ class SimulationManager:
         regions_config: RegionsConfig,
     ) -> List[Region]:
         """
-        Generate default regions from a :class:`RegionsConfig`.
+        Uses :func:`get_regions_default` to generate regions based on the configuration provided from dataclass :class:`RegionsConfig`
 
-        The returned list can be passed directly to :func:`initialize`
+        The returned list of regions can be passed directly to :func:`initialize`
 
         Parameters:
         regions_config : RegionsConfig

--- a/invertedai/helpers/simulation_manager.py
+++ b/invertedai/helpers/simulation_manager.py
@@ -1,11 +1,11 @@
 from typing import DefaultDict, List, Optional, Tuple
 from collections import defaultdict
-from invertedai.common import RECURRENT_SIZE, AgentState, AgentProperties, RecurrentState, AgentData
+from invertedai.common import RECURRENT_SIZE, AgentState, AgentProperties, AgentType, RecurrentState, AgentData
 from invertedai.api.initialize import InitializeResponse
 from invertedai.api.drive import DriveResponse
 from invertedai.helpers.waypoints import WaypointManagerConfig, WaypointManager
 from invertedai.utils import ScenePlotterConfig, ScenePlotter, WaypointsDict
-from invertedai.large.initialize import large_initialize
+from invertedai.large.initialize import large_initialize, get_regions_default, RegionsConfig
 from invertedai.large.drive import large_drive
 from invertedai.logs.logger import LogWriterConfig, LogWriter
 from invertedai.large.common import Region
@@ -57,6 +57,29 @@ class SimulationManager:
             if log_writer_cfg:
                 self.log_writer = LogWriter()   
     
+    def form_regions(
+        self,
+        regions_config: RegionsConfig,
+    ) -> List[Region]:
+        """
+        Generate default regions from a :class:`RegionsConfig`.
+
+        The returned list can be passed directly to :func:`initialize`
+
+        Parameters:
+        regions_config : RegionsConfig
+            Configuration specifying location, agent counts, area shape, etc.
+        """
+        return get_regions_default(
+            location=regions_config.location,
+            agent_count_dict=regions_config.agent_count_dict,
+            total_num_agents=regions_config.total_num_agents,
+            area_shape=regions_config.area_shape,
+            map_center=regions_config.map_center,
+            random_seed=regions_config.random_seed,
+            display_progress_bar=regions_config.display_progress_bar,
+        )
+
     def insert_agents(
         self,
         agent_data_list: List[AgentData],

--- a/invertedai/large/initialize.py
+++ b/invertedai/large/initialize.py
@@ -7,6 +7,7 @@ from copy import deepcopy
 from pydantic import BaseModel, validate_call
 from typing import Union, List, Optional, Tuple, Dict
 from itertools import product
+from pydantic.dataclasses import dataclass
 from tqdm.contrib import tenumerate
 
 import invertedai._state as _state
@@ -27,7 +28,35 @@ from invertedai.common import (
 
 AGENT_SCOPE_FOV_BUFFER = 60
 ATTEMPT_PER_NUM_REGIONS = 15
+@dataclass
+class RegionsConfig:
+    """
+    Configuration for generating default regions :func:`get_regions_default`.
 
+    Parameters:
+    location : str
+        Location name in IAI format.
+    agent_count_dict : Optional[Dict[AgentType, int]]
+        The number of agents to place within the regions per specified agent type.
+    total_num_agents : Optional[int]
+        Deprecated. The total number of agents to initialize across all regions.
+    area_shape : Optional[Tuple[float, float]]
+        Contains the [width, height] to either side of the center of the rectangular area.
+        If not provided, a bounding box around the location polygon will be used.
+    map_center : Optional[Tuple[float, float]]
+        The coordinates of the center of the rectangular area. Defaults to (0, 0).
+    random_seed : Optional[int]
+        Controls stochastic aspects of assigning agents to regions for reproducibility.
+    display_progress_bar : Optional[bool]
+        Whether to display a command line progress bar.
+    """
+    location: str
+    agent_count_dict: Optional[Dict[AgentType, int]] = None
+    total_num_agents: Optional[int] = None
+    area_shape: Optional[Tuple[float, float]] = None
+    map_center: Optional[Tuple[float, float]] = (0.0, 0.0)
+    random_seed: Optional[int] = None
+    display_progress_bar: Optional[bool] = False
 
 @validate_call
 def get_regions_default(

--- a/invertedai/large/initialize.py
+++ b/invertedai/large/initialize.py
@@ -38,8 +38,6 @@ class RegionsConfig:
         Location name in IAI format.
     agent_count_dict : Optional[Dict[AgentType, int]]
         The number of agents to place within the regions per specified agent type.
-    total_num_agents : Optional[int]
-        Deprecated. The total number of agents to initialize across all regions.
     area_shape : Optional[Tuple[float, float]]
         Contains the [width, height] to either side of the center of the rectangular area.
         If not provided, a bounding box around the location polygon will be used.

--- a/invertedai/large/initialize.py
+++ b/invertedai/large/initialize.py
@@ -52,7 +52,6 @@ class RegionsConfig:
     """
     location: str
     agent_count_dict: Optional[Dict[AgentType, int]] = None
-    total_num_agents: Optional[int] = None
     area_shape: Optional[Tuple[float, float]] = None
     map_center: Optional[Tuple[float, float]] = (0.0, 0.0)
     random_seed: Optional[int] = None


### PR DESCRIPTION
Adds `RegionsConfig` dataclass in` invertedai/large/initialize.py` that contains parameters for region generation (location, agent_count_dict, area_shape, map_center, random_seed, display_progress_bar)

Adds `SimulationManager.form_regions(regions_config)` method that accepts a `RegionsConfig` and returns `List[Region]`
The returned regions can be passed directly to` SimulationManager.initialize(regions=...)` or` iai.large_initialize(regions=...) `or inspected by the user before being used

Additional things done:
Exports `RegionsConfig` from the package __init__.py
Updates both existing example files that use `SimulationManager` to use the new pattern