### PR TITLE
EndOfRoadHandler tool to be used with SimulationManager

### DIFF
--- a/examples/simulation_manager_advanced_example.py
+++ b/examples/simulation_manager_advanced_example.py
@@ -32,6 +32,7 @@ scene_viz_cfg = SceneVisualizerConfig(
     ax=ax,
 )
 waypoint_cfg = WaypointManagerConfig(lanelet_map=location_info_response.get_lanelet_map())
+# for open maps it is recommended to use EndOfRoadHandler to prevent unrealistic behavior at the end of roads
 end_of_road_cfg = EndOfRoadConfig(
     lanelet_map=location_info_response.get_lanelet_map(), 
     remove_agent=True

--- a/examples/simulation_manager_advanced_example.py
+++ b/examples/simulation_manager_advanced_example.py
@@ -1,23 +1,28 @@
 import invertedai as iai
 from invertedai import AgentType
+from invertedai import WaypointManagerConfig
 from invertedai import SimulationManager
 from invertedai import SceneVisualizerConfig
+from invertedai import LogWriterConfig
 from invertedai import RegionsConfig
+from invertedai import EndOfRoadConfig
 import matplotlib.pyplot as plt
 import os
 
 
-LOCATION = "carla:Town10HD"
-NUM_AGENTS = 4 # number of agents initialized
-SIM_LENGTH=150 # number of timesteps
+LOCATION = "canada:drake_street_and_pacific_blvd"
+NUM_AGENTS = 7 # number of agents initialized
+SIM_LENGTH=100 # number of timesteps
 
-#export IAI_API_KEY=<INSERT_KEY_HERE> in your terminal before running the script, or specify your key here
 api_key = os.environ.get("IAI_API_KEY", None)
 if api_key is None:
     iai.add_apikey("<INSERT_KEY_HERE>")
 
 print("Begin initialization.")
-location_info_response = iai.location_info(location=LOCATION)
+location_info_response = iai.location_info(
+    location=LOCATION, 
+    include_map_source=True # must be set to True to get lanelet_map to use WaypointManager and EndOfRoadHandler
+)
 fig, ax = plt.subplots(constrained_layout=True, figsize=(10, 10))
 scene_viz_cfg = SceneVisualizerConfig(
     left_hand_coordinates=LOCATION.split(":")[0] == "carla",
@@ -26,7 +31,22 @@ scene_viz_cfg = SceneVisualizerConfig(
     fov=location_info_response.map_fov,
     ax=ax,
 )
-simulation_manager = SimulationManager(scene_visualizer_cfg=scene_viz_cfg)
+waypoint_cfg = WaypointManagerConfig(lanelet_map=location_info_response.get_lanelet_map())
+end_of_road_cfg = EndOfRoadConfig(
+    lanelet_map=location_info_response.get_lanelet_map(), 
+    remove_agent=True
+)
+log_cfg = LogWriterConfig(
+    log_path="simulation_manager_advanced_example_log.json",
+    location=LOCATION, 
+    location_info_response=location_info_response
+)
+simulation_manager = SimulationManager(
+    scene_visualizer_cfg=scene_viz_cfg, 
+    waypoint_cfg=waypoint_cfg, 
+    log_writer_cfg=log_cfg, 
+    end_of_road_cfg=end_of_road_cfg
+)
 regions_config = RegionsConfig(
     location=LOCATION, 
     agent_count_dict={AgentType.car: NUM_AGENTS}
@@ -44,5 +64,7 @@ for step in range(SIM_LENGTH):
     )
 
 print("Simulation finished, save visualization.")
-simulation_manager.visualize_data(output_name="simulation_manager_minimal_example.mp4")
+simulation_manager.visualize_data(output_name="simulation_manager_advanced_example.mp4")
+print("Simulation finished, save to json log.")
+simulation_manager.export_log()
 print("Done")

--- a/examples/simulation_manager_minimal_example.py
+++ b/examples/simulation_manager_minimal_example.py
@@ -21,8 +21,8 @@ print("Begin initialization.")
 location_info_response = iai.location_info(location=LOCATION, include_map_source=True)
 scene_plotter_cfg = ScenePlotterConfig(location=LOCATION, location_info_response=location_info_response)
 waypoint_cfg = WaypointManagerConfig(lanelet_map = location_info_response.get_lanelet_map())
-log_cfg = LogWriterConfig(log_path="keyed_minimal_example_log.json",location=LOCATION, location_info_response=location_info_response)
-simulation_manager = SimulationManager(scene_plotter_cfg=scene_plotter_cfg, waypoint_cfg=waypoint_cfg, log_writer_cfg=log_cfg)
+log_cfg = LogWriterConfig(log_path="simulation_manager_minimal_example_log.json",location=LOCATION, location_info_response=location_info_response)
+simulation_manager = SimulationManager(scene_plotter_cfg=scene_plotter_cfg, waypoint_cfg=waypoint_cfg, log_writer_cfg=log_cfg, remove_offroad_agents=True)
 regions_config = RegionsConfig(location=LOCATION, agent_count_dict={AgentType.car: NUM_AGENTS})
 regions = simulation_manager.form_regions(regions_config)
 response = simulation_manager.initialize(location=LOCATION, regions=regions)
@@ -37,7 +37,7 @@ print("Simulation finished, save visualization.")
 
 fig, ax = plt.subplots(constrained_layout=True, figsize=(10, 10))
 simulation_manager.visualize_data(
-    output_name="Simulation_manager_minimal_example.gif",
+    output_name="simulation_manager_minimal_example.gif",
     ax=ax,
     direction_vec=False,
     velocity_vec=False,

--- a/invertedai/__init__.py
+++ b/invertedai/__init__.py
@@ -54,6 +54,7 @@ from invertedai.logs.debug_logger import DebugLogger
 
 # --- Helpers ---
 from invertedai.helpers.waypoints import WaypointManagerConfig, WaypointManager
+from invertedai.helpers.end_of_road_handler import EndOfRoadConfig, EndOfRoadHandler
 from invertedai.simulation_manager import SimulationManager
 
 # --- Common data types ---
@@ -169,6 +170,8 @@ __all__ = [
     "AgentID",
     "SimulationAgentDict",
     "SimulationManager",
+    "EndOfRoadConfig",
+    "EndOfRoadHandler",
     # Session and utilities
     "session",
     "add_apikey",

--- a/invertedai/helpers/end_of_road_handler.py
+++ b/invertedai/helpers/end_of_road_handler.py
@@ -1,0 +1,141 @@
+from typing import Dict, List, Optional, Tuple
+from pydantic import BaseModel, ConfigDict
+from dataclasses import dataclass
+
+import lanelet2
+import numpy as np
+
+from invertedai.common import AgentState, AgentProperties, AgentData, RecurrentState, SimulationAgentDict
+from invertedai.helpers.waypoints import _find_direction_and_nearest_points
+
+_traffic_rules = lanelet2.traffic_rules.create(
+    lanelet2.traffic_rules.Locations.Germany,
+    lanelet2.traffic_rules.Participants.Vehicle
+)
+
+
+class EndOfRoadConfig(BaseModel):
+    """
+    Configuration for :class:`EndOfRoadHandler`.
+
+    Parameters:
+    lanelet_map : lanelet2.core.LaneletMapLayers
+        Projected lanelet map used to check for following lanelets.
+    waypoint_spacing : float
+        Distance threshold in meters. An agent whose best-aligned lanelet has
+        no successors and whose distance to that lanelet's endpoint is less than
+        this value is considered to be at the end of the road.
+    remove_agent : bool
+        If True, end-of-road agents are dropped from the simulation entirely 
+        they will not appear in subsequent drive calls, visualization, or logs.
+        If False, agents are frozen at their last known position and
+        continue to appear in visualization and logs.
+    """
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+    lanelet_map: lanelet2.core.LaneletMapLayers
+    waypoint_spacing: float = 3.0
+    remove_agent: bool = True
+
+
+class EndOfRoadHandler:
+    """
+    Detects agents approaching the end of the road
+
+    Detection uses only the lanelet routing graph and agent states
+    
+    SimulationManager calls :func:`update` before
+    calling WaypointManager so frozen agents retain their last valid waypoints,
+    and passes the resulting IDs as an ``agents_mask`` to
+    WaypointManager to stop waypoint generation for those agents.
+    """
+
+    def __init__(self, cfg: EndOfRoadConfig):
+        self.cfg = cfg
+        self._routing_graph = lanelet2.routing.RoutingGraph(cfg.lanelet_map, _traffic_rules)
+        self._end_of_road_ids: set = set()
+        self._frozen_agents: SimulationAgentDict = {}
+
+    def is_end_of_road(self, state: AgentState) -> bool:
+        """
+        Returns True if the agent is near the end of a lanelet with
+        no following lanelets in the routing graph
+
+        inspired by 'func:generate_lane_ids_from_lanelet_map' in helpers/waypoints.py
+        """
+        x, y, yaw = state.center.x, state.center.y, state.orientation
+        filtered_lanelets = []
+        for radius in [0.0, 0.1, 0.5, 1.0, 2.0, 5.0]:
+            starting_lanelets = lanelet2.geometry.findWithin2d(
+                self.cfg.lanelet_map.laneletLayer,
+                lanelet2.core.BasicPoint2d(x, y),
+                radius
+            )
+            for _, ll in sorted(starting_lanelets, key=lambda l: l[1].id):
+                a, b = _find_direction_and_nearest_points(
+                    ll.centerline,
+                    lanelet2.core.BasicPoint3d(x, y, 0)
+                )
+                lane_orientation = np.arctan2(b.y - a.y, b.x - a.x)
+                angle = np.absolute((yaw - lane_orientation + np.pi) % (2 * np.pi) - np.pi)
+                if angle < 75 * np.pi / 180:
+                    filtered_lanelets.append((ll, angle))
+            if filtered_lanelets:
+                break
+
+        if not filtered_lanelets:
+            return False
+
+        best_lanelet, _ = min(filtered_lanelets, key=lambda x: x[1])
+        if self._routing_graph.following(best_lanelet, withLaneChanges=False):
+            return False
+
+        end_point = best_lanelet.centerline[-1]
+        dist_to_end = np.sqrt((x - end_point.x) ** 2 + (y - end_point.y) ** 2)
+        return dist_to_end < self.cfg.waypoint_spacing
+
+    def update(
+        self,
+        agent_ids: List[str],
+        agent_states: List[AgentState],
+        properties: List[AgentProperties],
+        recurrent_states: List[RecurrentState],
+        external_ids: set,
+    ) -> None:
+        """
+        Detect new end of road agents and update internal state
+
+        Must be called with pre waypoint update agent_properties so frozen agents
+        retain their last valid waypoints rather than the empty list that
+        results from a failed generation attempt.
+        """
+        print("offroad agents", self._end_of_road_ids)
+        for i, aid in enumerate(agent_ids):
+            if aid in external_ids or aid in self._end_of_road_ids:
+                print(f"Skipping end of road check for agent {aid} since it is already marked as end of road or external")
+                continue
+            if self.is_end_of_road(agent_states[i]):
+                self._end_of_road_ids.add(aid)
+                if not self.cfg.remove_agent:
+                    self._frozen_agents[aid] = AgentData(
+                        state=agent_states[i],
+                        properties=properties[i],
+                        recurrent=recurrent_states[i],
+                    )
+
+    def get_agents_mask(self, agent_ids: List[str]) -> List[bool]:
+        """
+        Returns a boolean mask for WaypointManager.update() to skips
+        waypoint generation for all end of road agents.
+        """
+        return [aid not in self._end_of_road_ids for aid in agent_ids]
+
+    def get_frozen_agents(self) -> SimulationAgentDict:
+        """Returns the frozen agent dict for visualization frames and logs"""
+        return self._frozen_agents
+
+    def remove_agents(self, agent_ids: List[str]) -> None:
+        """Clean up handler state when agents are manually removed"""
+        for aid in agent_ids:
+            self._end_of_road_ids.discard(aid)
+            self._frozen_agents.pop(aid, None)
+

--- a/invertedai/helpers/end_of_road_handler.py
+++ b/invertedai/helpers/end_of_road_handler.py
@@ -26,10 +26,9 @@ class EndOfRoadConfig(BaseModel):
         no successors and whose distance to that lanelet's endpoint is less than
         this value is considered to be at the end of the road.
     remove_agent : bool
-        If True, end-of-road agents are dropped from the simulation entirely 
+        If True, end-of-road agents are dropped from the simulation entirely —
         they will not appear in subsequent drive calls, visualization, or logs.
-        If False, agents are frozen at their last known position and
-        continue to appear in visualization and logs.
+        If False, agents remain in drive calls but waypoint generation stops for them.
     """
     model_config = ConfigDict(arbitrary_types_allowed=True)
     lanelet_map: lanelet2.core.LaneletMapLayers
@@ -39,26 +38,25 @@ class EndOfRoadConfig(BaseModel):
 
 class EndOfRoadHandler:
     """
-    Detects agents approaching the end of the road
+    Detects agents approaching the end of the road.
 
-    Detection uses only the lanelet routing graph and agent states
-    
-    SimulationManager calls :func:`update` before
-    calling WaypointManager so frozen agents retain their last valid waypoints,
-    and passes the resulting IDs as an ``agents_mask`` to
-    WaypointManager to stop waypoint generation for those agents.
+    Detection uses only the lanelet routing graph and agent states.
+
+    SimulationManager calls :func:`update` before calling WaypointManager,
+    and passes the resulting IDs as an ``agents_mask`` to WaypointManager
+    to stop waypoint generation for end-of-road agents.
     """
 
     def __init__(self, cfg: EndOfRoadConfig):
         self.cfg = cfg
         self._routing_graph = lanelet2.routing.RoutingGraph(cfg.lanelet_map, _traffic_rules)
         self._end_of_road_ids: set = set()
-        self._frozen_agents: SimulationAgentDict = {}
+        self._end_of_road_agents: SimulationAgentDict = {}
 
     def is_end_of_road(self, state: AgentState) -> bool:
         """
         Returns True if the agent is near the end of a lanelet with
-        no following lanelets in the routing graph
+        no following lanelets in the routing graph.
 
         inspired by 'func:generate_lane_ids_from_lanelet_map' in helpers/waypoints.py
         """
@@ -102,40 +100,38 @@ class EndOfRoadHandler:
         external_ids: set,
     ) -> None:
         """
-        Detect new end of road agents and update internal state
+        Detect new end-of-road agents and record their state snapshot.
 
-        Must be called with pre waypoint update agent_properties so frozen agents
-        retain their last valid waypoints rather than the empty list that
-        results from a failed generation attempt.
+        Must be called with pre waypoint update agent_properties so that
+        the recorded snapshot retains the last valid waypoints.
         """
-        print("offroad agents", self._end_of_road_ids)
         for i, aid in enumerate(agent_ids):
             if aid in external_ids or aid in self._end_of_road_ids:
-                print(f"Skipping end of road check for agent {aid} since it is already marked as end of road or external")
                 continue
             if self.is_end_of_road(agent_states[i]):
                 self._end_of_road_ids.add(aid)
-                if not self.cfg.remove_agent:
-                    self._frozen_agents[aid] = AgentData(
-                        state=agent_states[i],
-                        properties=properties[i],
-                        recurrent=recurrent_states[i],
-                    )
+                self._end_of_road_agents[aid] = AgentData(
+                    state=agent_states[i],
+                    properties=properties[i],
+                    recurrent=recurrent_states[i],
+                )
 
     def get_agents_mask(self, agent_ids: List[str]) -> List[bool]:
         """
-        Returns a boolean mask for WaypointManager.update() to skips
-        waypoint generation for all end of road agents.
+        Returns a boolean mask for WaypointManager.update() to skip
+        waypoint generation for all end-of-road agents.
         """
         return [aid not in self._end_of_road_ids for aid in agent_ids]
 
-    def get_frozen_agents(self) -> SimulationAgentDict:
-        """Returns the frozen agent dict for visualization frames and logs"""
-        return self._frozen_agents
+    def get_end_of_road_agents(self) -> SimulationAgentDict:
+        """
+        Returns a SimulationAgentDict of every agent that has reached end-of-road,
+        keyed by agent ID, with state/properties/recurrent at time of detection.
+        """
+        return self._end_of_road_agents
 
     def remove_agents(self, agent_ids: List[str]) -> None:
-        """Clean up handler state when agents are manually removed"""
+        """Clean up handler state when agents are manually removed."""
         for aid in agent_ids:
             self._end_of_road_ids.discard(aid)
-            self._frozen_agents.pop(aid, None)
-
+            self._end_of_road_agents.pop(aid, None)

--- a/invertedai/helpers/end_of_road_handler.py
+++ b/invertedai/helpers/end_of_road_handler.py
@@ -21,7 +21,7 @@ class EndOfRoadConfig(BaseModel):
     Parameters:
     lanelet_map : lanelet2.core.LaneletMapLayers
         Projected lanelet map used to check for following lanelets.
-    waypoint_spacing : float
+    end_of_lanelet_spacing : float
         Distance threshold in meters. An agent whose best-aligned lanelet has
         no successors and whose distance to that lanelet's endpoint is less than
         this value is considered to be at the end of the road.
@@ -32,7 +32,7 @@ class EndOfRoadConfig(BaseModel):
     """
     model_config = ConfigDict(arbitrary_types_allowed=True)
     lanelet_map: lanelet2.core.LaneletMapLayers
-    waypoint_spacing: float = 3.0
+    end_of_lanelet_spacing: float = 3.0
     remove_agent: bool = True
 
 
@@ -89,7 +89,7 @@ class EndOfRoadHandler:
 
         end_point = best_lanelet.centerline[-1]
         dist_to_end = np.sqrt((x - end_point.x) ** 2 + (y - end_point.y) ** 2)
-        return dist_to_end < self.cfg.waypoint_spacing
+        return dist_to_end < self.cfg.end_of_lanelet_spacing
 
     def update(
         self,

--- a/invertedai/helpers/end_of_road_handler.py
+++ b/invertedai/helpers/end_of_road_handler.py
@@ -6,7 +6,7 @@ import lanelet2
 import numpy as np
 
 from invertedai.common import AgentState, AgentProperties, AgentData, RecurrentState, SimulationAgentDict
-from invertedai.helpers.waypoints import _find_direction_and_nearest_points
+from invertedai.helpers.waypoints import _find_aligned_lanelets
 
 _traffic_rules = lanelet2.traffic_rules.create(
     lanelet2.traffic_rules.Locations.Germany,
@@ -61,25 +61,7 @@ class EndOfRoadHandler:
         inspired by 'func:generate_lane_ids_from_lanelet_map' in helpers/waypoints.py
         """
         x, y, yaw = state.center.x, state.center.y, state.orientation
-        filtered_lanelets = []
-        for radius in [0.0, 0.1, 0.5, 1.0, 2.0, 5.0]:
-            starting_lanelets = lanelet2.geometry.findWithin2d(
-                self.cfg.lanelet_map.laneletLayer,
-                lanelet2.core.BasicPoint2d(x, y),
-                radius
-            )
-            for _, ll in sorted(starting_lanelets, key=lambda l: l[1].id):
-                a, b = _find_direction_and_nearest_points(
-                    ll.centerline,
-                    lanelet2.core.BasicPoint3d(x, y, 0)
-                )
-                lane_orientation = np.arctan2(b.y - a.y, b.x - a.x)
-                angle = np.absolute((yaw - lane_orientation + np.pi) % (2 * np.pi) - np.pi)
-                if angle < 75 * np.pi / 180:
-                    filtered_lanelets.append((ll, angle))
-            if filtered_lanelets:
-                break
-
+        filtered_lanelets = _find_aligned_lanelets(self.cfg.lanelet_map, x, y, yaw)
         if not filtered_lanelets:
             return False
 

--- a/invertedai/helpers/end_of_road_handler.py
+++ b/invertedai/helpers/end_of_road_handler.py
@@ -61,7 +61,7 @@ class EndOfRoadHandler:
         inspired by 'func:generate_lane_ids_from_lanelet_map' in helpers/waypoints.py
         """
         x, y, yaw = state.center.x, state.center.y, state.orientation
-        filtered_lanelets = _find_aligned_lanelets(self.cfg.lanelet_map, x, y, yaw)
+        filtered_lanelets, _ = _find_aligned_lanelets(self.cfg.lanelet_map, x, y, yaw)
         if not filtered_lanelets:
             return False
 

--- a/invertedai/helpers/scene_visualizer.py
+++ b/invertedai/helpers/scene_visualizer.py
@@ -388,6 +388,7 @@ class SceneVisualizer:
                     m.set_visible(False)
             else:
                 elem.set_visible(False)
+            marker["text"].set_visible(False)
         for lines in self.dir_lines.values():
             if isinstance(lines, list):
                 for line in lines:

--- a/invertedai/helpers/simulation_manager.py
+++ b/invertedai/helpers/simulation_manager.py
@@ -38,6 +38,7 @@ class SimulationManager:
             scene_plotter_cfg: Optional[ScenePlotterConfig] = None, # can optionally initialize a scene plotter for visualization
             waypoint_cfg : Optional[WaypointManagerConfig] = None, # can optionally initialize a waypointManager to manage waypoints
             log_writer_cfg: Optional[LogWriterConfig] = None, # can optionally initialize a log_writer_cfg to write a json file log of the simulation
+            remove_offroad_agents: bool = False, # if True, agents whose waypoints are empty after update (off-road/end-of-map) will be removed
         ):
             self.scene_plotter = None
             self.scene_plotter_cfg = scene_plotter_cfg
@@ -49,6 +50,7 @@ class SimulationManager:
                     scene_plotter_cfg.location_info_response.static_actors,
                     left_hand_coordinates = scene_plotter_cfg.location.split(":")[0] == "carla"
                 )
+            self.remove_offroad_agents = remove_offroad_agents
             self.agents_dict: SimulationAgentDict = defaultdict(AgentData)
             self.waypoint_manager: Optional[WaypointManager] = None
             if waypoint_cfg:
@@ -327,6 +329,9 @@ class SimulationManager:
             if overlap:
                 raise ValueError(f"External agent IDs conflict with internal agents: {overlap}")
             
+        if not self.agents_dict and not external_agent_data:
+            raise ValueError("No agents remaining in simulation. All agents have been removed.")
+
         agent_ids, states, properties, recurrent_states = self._unpack(self.agents_dict)
         if len(recurrent_states) > 0: 
              internal_recur_size = len(recurrent_states[0].packed)
@@ -356,14 +361,19 @@ class SimulationManager:
             recurrent_states=recurrent_states,
             **kwargs
         )
+        offroad_ids = set()
         if self.waypoint_manager:
             properties = self.waypoint_manager.update(
                 response = response,
                 agent_properties = properties,
             )
+            if self.remove_offroad_agents:
+                for i, aid in enumerate(agent_ids):
+                    if aid not in external_ids and properties[i].waypoints == []:
+                        offroad_ids.add(aid)
         internal_indices = []
         for i, aid in enumerate(agent_ids):
-            if aid not in external_ids:
+            if aid not in external_ids and aid not in offroad_ids:
                 internal_indices.append(i)
         self.agents_dict = self._pack(
             agent_ids=[agent_ids[i] for i in internal_indices],

--- a/invertedai/helpers/simulation_manager.py
+++ b/invertedai/helpers/simulation_manager.py
@@ -51,6 +51,7 @@ class SimulationManager:
                     left_hand_coordinates = scene_plotter_cfg.location.split(":")[0] == "carla"
                 )
             self.remove_offroad_agents = remove_offroad_agents
+            self._offroad_agent_ids: set = set()
             self.agents_dict: SimulationAgentDict = defaultdict(AgentData)
             self.waypoint_manager: Optional[WaypointManager] = None
             if waypoint_cfg:
@@ -132,6 +133,8 @@ class SimulationManager:
             raise KeyError(f"Agents do not exist: {missing}. Cannot be removed.")
         for aid in agent_ids:
             self.agents_dict.pop(aid)
+            if aid in self._offroad_agent_ids:
+                self._offroad_agent_ids.remove(aid)
     
     def _unpack(
         self,
@@ -143,7 +146,7 @@ class SimulationManager:
         List[RecurrentState],
     ]:
         # agents with both properties and states will be placed at the front of the list
-        # Separate agents into two groups: with states & without states
+        # separate agents into two groups: with states & without states
         agents_with_states = []
         agents_without_states = []
         if agent_dict is None:
@@ -361,19 +364,21 @@ class SimulationManager:
             recurrent_states=recurrent_states,
             **kwargs
         )
-        offroad_ids = set()
         if self.waypoint_manager:
+            #Skip waypoint update for off-road agents
+            agents_mask = [aid not in self._offroad_agent_ids for aid in agent_ids]
             properties = self.waypoint_manager.update(
-                response = response,
-                agent_properties = properties,
+                response=response,
+                agent_properties=properties,
+                agents_mask=agents_mask,
             )
-            if self.remove_offroad_agents:
-                for i, aid in enumerate(agent_ids):
-                    if aid not in external_ids and properties[i].waypoints == []:
-                        offroad_ids.add(aid)
+            #Detect off-road agents (EndOfMapException sets waypoints=[])
+            for i, aid in enumerate(agent_ids):
+                if aid not in external_ids and properties[i].waypoints is not None and len(properties[i].waypoints) == 0:
+                    self._offroad_agent_ids.add(aid)
         internal_indices = []
         for i, aid in enumerate(agent_ids):
-            if aid not in external_ids and aid not in offroad_ids:
+            if aid not in external_ids and (not self.remove_offroad_agents or aid not in self._offroad_agent_ids):
                 internal_indices.append(i)
         self.agents_dict = self._pack(
             agent_ids=[agent_ids[i] for i in internal_indices],

--- a/invertedai/helpers/waypoints.py
+++ b/invertedai/helpers/waypoints.py
@@ -38,6 +38,13 @@ class WaypointManagerConfig(BaseModel):
     log_level: Optional[int] = logging.DEBUG #Configure the level of the logger for convenience 
     fail_soft: Optional[bool] = False #If an error is experienced, the manager will continue in a fail soft state instead of raising an Exception
 
+class EndOfMapException(Exception):
+    """
+    Raised when an agent has reached the end of the map and no further waypoints
+    can be generated. The routing graph has no successor lanes from the agent's current position.
+    """
+    pass
+
 class WaypointUpdateFlags(Enum):
     UNINITIALIZE_WAYPOINTS = 0
     WAYPOINT_REACHED = 1
@@ -128,6 +135,10 @@ class WaypointManager:
             state = agent_states[i]
 
             if mask or target_paths[i] is not None:
+                if agent_properties[i].waypoints is not None and len(agent_properties[i].waypoints) == 0:
+                    props.waypoints = []
+                    _agent_properties[i] = props
+                    continue
                 try:
                     waypoint_flags = []
                     if props.waypoints is None:
@@ -138,7 +149,9 @@ class WaypointManager:
                             target_path = target_paths[i],
                             agent_properties = props
                         )
-                    
+                        if len(props.waypoints) == 0:
+                            raise EndOfMapException(f"No waypoints generated for agent at {state}")
+
                     if len(props.waypoints) > 0:
                         # Most common case, check if current waypoint is achieved
                         if self.check_waypoint_achieved(
@@ -153,6 +166,8 @@ class WaypointManager:
                         #Do not pass the original target path as it should be completed if the list is empty
                         waypoint_flags.append(WaypointUpdateFlags.WAYPOINTS_EMPTY)
                         props.waypoints = self.generate_waypoints(state=state)
+                        if len(props.waypoints) == 0:
+                            raise EndOfMapException(f"No waypoints generated for agent at {state}")
 
                     if self.is_missed_waypoint(
                         state = state,
@@ -165,6 +180,13 @@ class WaypointManager:
                             target_path = target_paths[i],
                             agent_properties = props
                         )
+                        if len(props.waypoints) == 0:
+                            raise EndOfMapException(f"No waypoints generated for agent at {state}")
+
+                except (EndOfMapException, IndexError) as e:
+                    if self.logger is not None:
+                        self.logger.debug(msg=str(e))
+                    props.waypoints = []
 
                 except ValueError as e:
                     err_msg = str(e)
@@ -239,7 +261,8 @@ class WaypointManager:
                     lanelet_map=self.lanelet_map,
                     destination_waypoint=destination_waypoint,
                     seed=self.rng.integers(low=1, high=1000000000),
-                    logger=self.logger
+                    logger=self.logger,
+                    waypoint_spacing=self.waypoint_spacing
                 )
             )
 
@@ -269,13 +292,22 @@ class WaypointManager:
         ):
             props = AgentProperties.deserialize(agent_properties.serialize())
             props.waypoints = None
-            wps = self.generate_waypoints(
-                state = state,
-                target_path = [wp],
-                agent_properties = props,
-                waypoint_spacing = 1.0
-            )
-            
+            try:
+                wps = self.generate_waypoints(
+                    state = state,
+                    target_path = [wp],
+                    agent_properties = props,
+                    waypoint_spacing = 1.0
+                )
+            except (EndOfMapException, ValueError, IndexError) as e:
+                if logger is not None: 
+                    msg = f"Error encountered when generating waypoints for missed waypoint check. This is likely due to the agent being close to the end of the map. Error details: {str(e)}"
+                    logger.log(
+                        level=logger.getEffectiveLevel(),
+                        msg=msg
+                    )
+                return False
+
             dist_sum = 0.0
             for i in range(len(wps)-1):
                 dist_sum += self._get_L2_distance(wps[i],wps[i+1])
@@ -469,19 +501,21 @@ def generate_lane_ids_from_lanelet_map(
     min_distance: Optional[float] = 1000.0, 
     destination_waypoint: Optional[Point] = None,
     seed: Optional[int] = None,
-    logger: Optional[logging.Logger] = None
+    logger: Optional[logging.Logger] = None,
+    waypoint_spacing: Optional[float] = 20.0
 ) -> List[int]:
     """
     Generates a sequence of lane ids. If given a waypoint, it will generate the shortest possible route between
-    current starting state and the specified waypoint. Otherwise, a random route will be generated that is at 
+    current starting state and the specified waypoint. Otherwise, a random route will be generated that is at
     least `min_distance` long in meters unless there are no more lanes to follow.
-    
+
     Args:
         start_state (AgentState): The starting state of the agent.
         lanelet_map (lanelet2.core.LaneletMapLayers): Projected lanelet map.
         min_distance (Optional[float]): Minimum distance in meters to generate. Ignored if destination_waypoint is specified. Defaults to 1000.
         destination_waypoint (Optional[Point], optional): Desired final waypoint. Defaults to None.
         seed (Optional[int]): Random seed for reproducibility. Defaults to None.
+        waypoint_spacing (Optional[float]): Distance threshold in meters to detect when an agent is near the end of the map. Defaults to 30.
 
     Returns:
         List[int]: Sequence of lane ids to follow. Empty if no routes are possible.
@@ -517,6 +551,16 @@ def generate_lane_ids_from_lanelet_map(
                 msg=msg
             )
         return []
+    # check if the best-aligned lanelet has no successors and the agent the end of road
+    best_lanelet, _ = min(filtered_lanelets, key=lambda x: x[1])
+    if not routing_graph.following(best_lanelet, withLaneChanges=True):
+        end_point = best_lanelet.centerline[-1]
+        dist_to_end = np.sqrt((x - end_point.x)**2 + (y - end_point.y)**2)
+        if dist_to_end < (waypoint_spacing if waypoint_spacing is not None else 30.0):
+            raise EndOfMapException(
+                f"Agent is near the edge of the map with no following lanelets: {start_state}"
+            )
+
     if destination_waypoint is not None:
         ending_lanelets = lanelet2.geometry.findWithin2d(lanelet_map.laneletLayer, lanelet2.core.BasicPoint2d(destination_waypoint.x, destination_waypoint.y), 0)
         possible_routes = []
@@ -565,6 +609,10 @@ def generate_lane_ids_from_lanelet_map(
             ending_lanelets = sorted(list(routing_graph.reachableSet(starting_lanelet, maxRoutingCost=maxRoutingCost, allowLaneChanges=True)), key=lambda lanelet: lanelet.id)
             total_distance += route.length2d()
             route_lane_ids.extend([lanelet.id for lanelet in list(route.shortestPath())[1:]])
+        if not ending_lanelets and total_distance < (waypoint_spacing if waypoint_spacing is not None else 20.0):
+            raise EndOfMapException(
+                f"Agent has less than one waypoint spacing of road remaining: {start_state}"
+            )
         return route_lane_ids
 
 def _find_max_num_lane_change(routing_graph: lanelet2.routing.RoutingGraph, route: lanelet2.routing.LaneletPath):

--- a/invertedai/helpers/waypoints.py
+++ b/invertedai/helpers/waypoints.py
@@ -36,15 +36,7 @@ class WaypointManagerConfig(BaseModel):
     waypoint_spacing: float = 30.0 #Distance in meters between waypoints along a path to an end goal
     random_seed: int = int(time.time()) #Pseudo-random seed for repeatability
     log_level: Optional[int] = logging.DEBUG #Configure the level of the logger for convenience 
-    fail_soft: Optional[bool] = False #If an error is experienced, the manager will continue in a fail soft state instead of raising an Exception
-    remove_end_of_road_agents: bool = False #Whether to remove agents that have reached the end of the road and have no more lanes to follow
-
-class EndOfMapException(Exception):
-    """
-    Raised when an agent has reached the end of the map and no further waypoints
-    can be generated. The routing graph has no successor lanes from the agent's current position.
-    """
-    pass
+    fail_soft: Optional[bool] = True #If an error is experienced, the manager will continue in a fail soft state instead of raising an Exception
 
 class WaypointUpdateFlags(Enum):
     UNINITIALIZE_WAYPOINTS = 0
@@ -146,9 +138,7 @@ class WaypointManager:
                             target_path = target_paths[i],
                             agent_properties = props
                         )
-                        if len(props.waypoints) == 0:
-                            raise EndOfMapException(f"No waypoints generated for agent at {state}")
-
+                    
                     if len(props.waypoints) > 0:
                         # Most common case, check if current waypoint is achieved
                         if self.check_waypoint_achieved(
@@ -163,8 +153,6 @@ class WaypointManager:
                         #Do not pass the original target path as it should be completed if the list is empty
                         waypoint_flags.append(WaypointUpdateFlags.WAYPOINTS_EMPTY)
                         props.waypoints = self.generate_waypoints(state=state)
-                        if len(props.waypoints) == 0:
-                            raise EndOfMapException(f"No waypoints generated for agent at {state}")
 
                     if self.is_missed_waypoint(
                         state = state,
@@ -177,13 +165,6 @@ class WaypointManager:
                             target_path = target_paths[i],
                             agent_properties = props
                         )
-                        if len(props.waypoints) == 0:
-                            raise EndOfMapException(f"No waypoints generated for agent at {state}")
-
-                except (EndOfMapException, IndexError) as e:
-                    if self.logger is not None:
-                        self.logger.debug(msg=str(e))
-                    props.waypoints = []
 
                 except ValueError as e:
                     err_msg = str(e)
@@ -258,8 +239,7 @@ class WaypointManager:
                     lanelet_map=self.lanelet_map,
                     destination_waypoint=destination_waypoint,
                     seed=self.rng.integers(low=1, high=1000000000),
-                    logger=self.logger,
-                    waypoint_spacing=self.waypoint_spacing
+                    logger=self.logger
                 )
             )
 
@@ -289,22 +269,13 @@ class WaypointManager:
         ):
             props = AgentProperties.deserialize(agent_properties.serialize())
             props.waypoints = None
-            try:
-                wps = self.generate_waypoints(
-                    state = state,
-                    target_path = [wp],
-                    agent_properties = props,
-                    waypoint_spacing = 1.0
-                )
-            except (EndOfMapException, ValueError, IndexError) as e:
-                if logger is not None: 
-                    msg = f"Error encountered when generating waypoints for missed waypoint check. This is likely due to the agent being close to the end of the map. Error details: {str(e)}"
-                    logger.log(
-                        level=logger.getEffectiveLevel(),
-                        msg=msg
-                    )
-                return False
-
+            wps = self.generate_waypoints(
+                state = state,
+                target_path = [wp],
+                agent_properties = props,
+                waypoint_spacing = 1.0
+            )
+            
             dist_sum = 0.0
             for i in range(len(wps)-1):
                 dist_sum += self._get_L2_distance(wps[i],wps[i+1])
@@ -498,21 +469,19 @@ def generate_lane_ids_from_lanelet_map(
     min_distance: Optional[float] = 1000.0, 
     destination_waypoint: Optional[Point] = None,
     seed: Optional[int] = None,
-    logger: Optional[logging.Logger] = None,
-    waypoint_spacing: Optional[float] = 20.0
+    logger: Optional[logging.Logger] = None
 ) -> List[int]:
     """
     Generates a sequence of lane ids. If given a waypoint, it will generate the shortest possible route between
-    current starting state and the specified waypoint. Otherwise, a random route will be generated that is at
+    current starting state and the specified waypoint. Otherwise, a random route will be generated that is at 
     least `min_distance` long in meters unless there are no more lanes to follow.
-
+    
     Args:
         start_state (AgentState): The starting state of the agent.
         lanelet_map (lanelet2.core.LaneletMapLayers): Projected lanelet map.
         min_distance (Optional[float]): Minimum distance in meters to generate. Ignored if destination_waypoint is specified. Defaults to 1000.
         destination_waypoint (Optional[Point], optional): Desired final waypoint. Defaults to None.
         seed (Optional[int]): Random seed for reproducibility. Defaults to None.
-        waypoint_spacing (Optional[float]): Distance threshold in meters to detect when an agent is near the end of the map. Defaults to 30.
 
     Returns:
         List[int]: Sequence of lane ids to follow. Empty if no routes are possible.
@@ -548,15 +517,6 @@ def generate_lane_ids_from_lanelet_map(
                 msg=msg
             )
         return []
-    # check if the best-aligned lanelet has no successors and the agent the end of road
-    best_lanelet, _ = min(filtered_lanelets, key=lambda x: x[1])
-    if not routing_graph.following(best_lanelet, withLaneChanges=True):
-        end_point = best_lanelet.centerline[-1]
-        dist_to_end = np.sqrt((x - end_point.x)**2 + (y - end_point.y)**2)
-        if dist_to_end < (waypoint_spacing if waypoint_spacing is not None else 30.0):
-            raise EndOfMapException(
-                f"Agent is near the edge of the map with no following lanelets: {start_state}"
-            )
 
     if destination_waypoint is not None:
         ending_lanelets = lanelet2.geometry.findWithin2d(lanelet_map.laneletLayer, lanelet2.core.BasicPoint2d(destination_waypoint.x, destination_waypoint.y), 0)
@@ -606,10 +566,6 @@ def generate_lane_ids_from_lanelet_map(
             ending_lanelets = sorted(list(routing_graph.reachableSet(starting_lanelet, maxRoutingCost=maxRoutingCost, allowLaneChanges=True)), key=lambda lanelet: lanelet.id)
             total_distance += route.length2d()
             route_lane_ids.extend([lanelet.id for lanelet in list(route.shortestPath())[1:]])
-        if not ending_lanelets and total_distance < (waypoint_spacing if waypoint_spacing is not None else 20.0):
-            raise EndOfMapException(
-                f"Agent has less than one waypoint spacing of road remaining: {start_state}"
-            )
         return route_lane_ids
 
 def _find_max_num_lane_change(routing_graph: lanelet2.routing.RoutingGraph, route: lanelet2.routing.LaneletPath):

--- a/invertedai/helpers/waypoints.py
+++ b/invertedai/helpers/waypoints.py
@@ -135,10 +135,6 @@ class WaypointManager:
             state = agent_states[i]
 
             if mask or target_paths[i] is not None:
-                if agent_properties[i].waypoints is not None and len(agent_properties[i].waypoints) == 0:
-                    props.waypoints = []
-                    _agent_properties[i] = props
-                    continue
                 try:
                     waypoint_flags = []
                     if props.waypoints is None:

--- a/invertedai/helpers/waypoints.py
+++ b/invertedai/helpers/waypoints.py
@@ -489,32 +489,13 @@ def generate_lane_ids_from_lanelet_map(
     rng = np.random.default_rng(seed)
     routing_graph = lanelet2.routing.RoutingGraph(lanelet_map, traffic_rules)
     x, y, yaw = start_state.center.x, start_state.center.y, start_state.orientation
-    filtered_lanelets = []
-    radius_to_check = [0.0, 0.1, 0.5, 1.0, 2.0, 5.0]
     beta = 5.0 # parameter for lane change probability
-    for radius in radius_to_check:
-        starting_lanelets = lanelet2.geometry.findWithin2d(lanelet_map.laneletLayer, lanelet2.core.BasicPoint2d(x, y), radius)
-        for _, lanelet in sorted(starting_lanelets, key=lambda lanelet: lanelet[1].id): # laneletLayer is backed by an unordered_map, so we sort by id to have deterministic behavior
-            a, b = _find_direction_and_nearest_points(lanelet.centerline, lanelet2.core.BasicPoint3d(x, y, 0))
-            lane_orientation = np.arctan2(b.y - a.y, b.x - a.x)
-            angle = np.absolute((yaw - lane_orientation + np.pi) % (2 * np.pi) - np.pi)
-            if angle < 75 * np.pi / 180:
-                filtered_lanelets.append((lanelet, angle))
-        if len(filtered_lanelets) > 0:
-            break
-    if len(starting_lanelets) == 0:
-        msg = f"Warning: Could not find any lanes in the starting position."
-        if logger is not None: logger.log(
-            level=logger.getEffectiveLevel(),
-            msg=msg
-        )
-        return []
-    if len(filtered_lanelets) == 0:
-        if logger is not None: 
-            msg = f"Warning: Could not find any lanes aligned with the agent's orientation."
+    filtered_lanelets = _find_aligned_lanelets(lanelet_map, x, y, yaw)
+    if not filtered_lanelets:
+        if logger is not None:
             logger.log(
                 level=logger.getEffectiveLevel(),
-                msg=msg
+                msg="Warning: Could not find any lanes aligned with the agent's orientation."
             )
         return []
 
@@ -609,6 +590,30 @@ def _find_direction_and_nearest_points(
         point_b, point_a = linestring[second_closest_point_idx], linestring[closest_point_idx]
 
     return point_a, point_b
+
+def _find_aligned_lanelets(
+    lanelet_map: lanelet2.core.LaneletMapLayers,
+    x: float,
+    y: float,
+    yaw: float,
+) -> List[Tuple]:
+    """Search expanding radii for lanelets whose heading is within 75° of yaw."""
+    filtered_lanelets = []
+    for radius in [0.0, 0.1, 0.5, 1.0, 2.0, 5.0]:
+        starting_lanelets = lanelet2.geometry.findWithin2d(
+            lanelet_map.laneletLayer,
+            lanelet2.core.BasicPoint2d(x, y),
+            radius
+        )
+        for _, lanelet in sorted(starting_lanelets, key=lambda l: l[1].id):
+            a, b = _find_direction_and_nearest_points(lanelet.centerline, lanelet2.core.BasicPoint3d(x, y, 0))
+            lane_orientation = np.arctan2(b.y - a.y, b.x - a.x)
+            angle = np.absolute((yaw - lane_orientation + np.pi) % (2 * np.pi) - np.pi)
+            if angle < 75 * np.pi / 180:
+                filtered_lanelets.append((lanelet, angle))
+        if filtered_lanelets:
+            break
+    return filtered_lanelets
 
 def _hermite_spline(
     p0: np.ndarray, 

--- a/invertedai/helpers/waypoints.py
+++ b/invertedai/helpers/waypoints.py
@@ -37,6 +37,7 @@ class WaypointManagerConfig(BaseModel):
     random_seed: int = int(time.time()) #Pseudo-random seed for repeatability
     log_level: Optional[int] = logging.DEBUG #Configure the level of the logger for convenience 
     fail_soft: Optional[bool] = False #If an error is experienced, the manager will continue in a fail soft state instead of raising an Exception
+    remove_end_of_road_agents: bool = False #Whether to remove agents that have reached the end of the road and have no more lanes to follow
 
 class EndOfMapException(Exception):
     """

--- a/invertedai/helpers/waypoints.py
+++ b/invertedai/helpers/waypoints.py
@@ -490,7 +490,11 @@ def generate_lane_ids_from_lanelet_map(
     routing_graph = lanelet2.routing.RoutingGraph(lanelet_map, traffic_rules)
     x, y, yaw = start_state.center.x, start_state.center.y, start_state.orientation
     beta = 5.0 # parameter for lane change probability
-    filtered_lanelets = _find_aligned_lanelets(lanelet_map, x, y, yaw)
+    filtered_lanelets, any_found = _find_aligned_lanelets(lanelet_map, x, y, yaw)
+    if not any_found:
+        if logger is not None:
+            logger.log(level=logger.getEffectiveLevel(), msg="Warning: Could not find any lanes in the starting position.")
+        return []
     if not filtered_lanelets:
         if logger is not None:
             logger.log(
@@ -596,15 +600,22 @@ def _find_aligned_lanelets(
     x: float,
     y: float,
     yaw: float,
-) -> List[Tuple]:
-    """Search expanding radii for lanelets whose heading is within 75° of yaw."""
+) -> Tuple[List[Tuple], bool]:
+    """Search expanding radii for lanelets whose heading is within 75° of yaw.
+
+    Returns (filtered_lanelets, any_found) where any_found is True if any
+    lanelets were found within any radius
+    """
     filtered_lanelets = []
+    any_found = False
     for radius in [0.0, 0.1, 0.5, 1.0, 2.0, 5.0]:
         starting_lanelets = lanelet2.geometry.findWithin2d(
             lanelet_map.laneletLayer,
             lanelet2.core.BasicPoint2d(x, y),
             radius
         )
+        if starting_lanelets:
+            any_found = True
         for _, lanelet in sorted(starting_lanelets, key=lambda l: l[1].id):
             a, b = _find_direction_and_nearest_points(lanelet.centerline, lanelet2.core.BasicPoint3d(x, y, 0))
             lane_orientation = np.arctan2(b.y - a.y, b.x - a.x)
@@ -613,7 +624,7 @@ def _find_aligned_lanelets(
                 filtered_lanelets.append((lanelet, angle))
         if filtered_lanelets:
             break
-    return filtered_lanelets
+    return filtered_lanelets, any_found
 
 def _hermite_spline(
     p0: np.ndarray, 

--- a/invertedai/simulation_manager.py
+++ b/invertedai/simulation_manager.py
@@ -6,6 +6,7 @@ from invertedai.common import RECURRENT_SIZE, AgentState, AgentProperties, Recur
 from invertedai.api.initialize import InitializeResponse
 from invertedai.api.drive import DriveResponse
 from invertedai.helpers.waypoints import WaypointManagerConfig, WaypointManager
+from invertedai.helpers.end_of_road_handler import EndOfRoadConfig, EndOfRoadHandler
 from invertedai.utils import ScenePlotterConfig
 from invertedai.helpers.scene_visualizer import SceneVisualizer, SceneVisualizerConfig, FrameData, AgentTag
 from invertedai.large.initialize import large_initialize, get_regions_default, RegionsConfig
@@ -33,6 +34,9 @@ class SimulationManager:
     log_writer_cfg : Optional[LogWriterConfig]
         Configuration for enabling structured logging of the simulation
         If provided all initialize and drive steps will be recorded to a JSON log
+    end_of_road_cfg : Optional[EndOfRoadConfig]
+        Configuration for enabling end-of-road detection and handling
+        If provided, agents approaching the end of the road will be automatically detected and handled according to the configuration
     """
     def __init__(
             self,
@@ -40,6 +44,7 @@ class SimulationManager:
             scene_plotter_cfg: Optional[ScenePlotterConfig] = None, # deprecated: use scene_visualizer_cfg instead
             waypoint_cfg : Optional[WaypointManagerConfig] = None, # can optionally initialize a waypointManager to manage waypoints
             log_writer_cfg: Optional[LogWriterConfig] = None, # can optionally initialize a log_writer_cfg to write a json file log of the simulation
+            end_of_road_cfg: Optional[EndOfRoadConfig] = None,
         ):
             if scene_plotter_cfg is not None:
                 warnings.warn('scene_plotter_cfg is deprecated. Use scene_visualizer_cfg instead.', category=DeprecationWarning)
@@ -63,9 +68,11 @@ class SimulationManager:
             self.agents_dict: SimulationAgentDict = defaultdict(AgentData)
             self.agent_tags: Optional[dict] = None  # Dict[AgentID, AgentTag] — applied to every recorded frame
             self.waypoint_manager: Optional[WaypointManager] = None
-            self.remove_offroad_agents = waypoint_cfg.remove_end_of_road_agents if waypoint_cfg else False
+            self.end_of_road_handler: Optional[EndOfRoadHandler] = None
             if waypoint_cfg:
                 self.waypoint_manager = WaypointManager(cfg=waypoint_cfg)
+            if end_of_road_cfg:
+                self.end_of_road_handler=EndOfRoadHandler(end_of_road_cfg)
             self.log_writer = None
             self.log_writer_cfg = log_writer_cfg
             if log_writer_cfg:
@@ -138,13 +145,16 @@ class SimulationManager:
         KeyError
             If any AgentID does not exist in self.agents_dict
         """
-        missing = [aid for aid in agent_ids if aid not in self.agents_dict]
+        all_ids = set(self.agents_dict.keys())
+        if self.end_of_road_handler:
+            all_ids = all_ids.union(self.end_of_road_handler._end_of_road_ids) # need to check both sets of ids
+        missing = [aid for aid in agent_ids if aid not in all_ids]
         if missing:
             raise KeyError(f"Agents do not exist: {missing}. Cannot be removed.")
         for aid in agent_ids:
-            self.agents_dict.pop(aid)
-            if aid in self._offroad_agent_ids:
-                self._offroad_agent_ids.remove(aid)
+            self.agents_dict.pop(aid, None)
+        if self.end_of_road_handler:
+            self.end_of_road_handler.remove_agents(agent_ids)
     
     def _unpack(
         self,
@@ -345,9 +355,15 @@ class SimulationManager:
         if not self.agents_dict and not external_agent_data:
             raise ValueError("No agents remaining in simulation. All agents have been removed.")
 
-        agent_ids, states, properties, recurrent_states = self._unpack(self.agents_dict)
+        # dont include end of road agents in DRIVE call
+        on_road = (
+            {k: v for k, v in self.agents_dict.items()
+             if k not in self.end_of_road_handler._end_of_road_ids}
+            if self.end_of_road_handler else self.agents_dict
+        )
+        agent_ids, states, properties, recurrent_states = self._unpack(on_road)
         if len(recurrent_states) > 0: 
-             internal_recur_size = len(recurrent_states[0].packed)
+            internal_recur_size = len(recurrent_states[0].packed)
         else: 
             internal_recur_size = RECURRENT_SIZE
         if external_agent_data:
@@ -374,31 +390,48 @@ class SimulationManager:
             recurrent_states=recurrent_states,
             **kwargs
         )
+
+        # detect end of road before waypoint update so agents retain their last valid waypoints
+        if self.end_of_road_handler:
+            self.end_of_road_handler.update(
+                agent_ids=agent_ids,
+                agent_states=response.agent_states,
+                properties=properties,
+                recurrent_states=response.recurrent_states,
+                external_ids=external_ids,
+            )
+
         if self.waypoint_manager:
-            #Skip waypoint update for off-road agents
-            agents_mask = [aid not in self._offroad_agent_ids for aid in agent_ids]
+            agents_mask = (
+                self.end_of_road_handler.get_agents_mask(agent_ids)
+                if self.end_of_road_handler else None
+            )
             properties = self.waypoint_manager.update(
                 response=response,
                 agent_properties=properties,
                 agents_mask=agents_mask,
             )
-            #Detect off-road agents (EndOfMapException sets waypoints=[])
-            for i, aid in enumerate(agent_ids):
-                if aid not in external_ids and properties[i].waypoints is not None and len(properties[i].waypoints) == 0:
-                    self._offroad_agent_ids.add(aid)
-        internal_indices = []
-        for i, aid in enumerate(agent_ids):
-            if aid not in external_ids and (not self.remove_offroad_agents or aid not in self._offroad_agent_ids):
-                internal_indices.append(i)
+
+        remove_ids = self.end_of_road_handler._end_of_road_ids if (self.end_of_road_handler and self.end_of_road_handler.cfg.remove_agent) else set()
+        internal_indices = [i for i, aid in enumerate(agent_ids) if aid not in external_ids and aid not in remove_ids]
         self.agents_dict = self._pack(
             agent_ids=[agent_ids[i] for i in internal_indices],
             states=[response.agent_states[i] for i in internal_indices],
             properties=[properties[i] for i in internal_indices],
             recurrent_states=[response.recurrent_states[i] for i in internal_indices],
         )
+
         if self.scene_visualizer is not None:
+            frame_states = list(response.agent_states)
+            frame_props = list(properties)
+            frame_ids = list(agent_ids)
+            if self.end_of_road_handler and not self.end_of_road_handler.cfg.remove_agent:
+                for fid, fdata in self.end_of_road_handler.get_frozen_agents().items():
+                    frame_ids.append(fid)
+                    frame_states.append(fdata.state)
+                    frame_props.append(fdata.properties)
             self._frames.append(FrameData(
-                agents=FrameData.agents_from_lists(response.agent_states, properties, agent_ids),
+                agents=FrameData.agents_from_lists(frame_states, frame_props, frame_ids),
                 traffic_lights=response.traffic_lights_states,
                 agent_tags=self.agent_tags,
             ))
@@ -409,6 +442,8 @@ class SimulationManager:
                 properties=properties,
                 recurrent_states=response.recurrent_states,
             )
+            if self.end_of_road_handler and not self.end_of_road_handler.cfg.remove_agent:
+                all_agents_dict.update(self.end_of_road_handler.get_frozen_agents())
             if self.log_writer is not None:
                 self.log_writer.drive(
                     drive_response=response,

--- a/invertedai/simulation_manager.py
+++ b/invertedai/simulation_manager.py
@@ -400,9 +400,7 @@ class SimulationManager:
                 recurrent_states=response.recurrent_states,
                 external_ids=external_ids,
             )
-
-        #no more waypoints fro agents that have reached end of road even if they still in simulation
-        if self.end_of_road_handler:
+        #stop generating waypoints for agents that have reached end of road
             for i, aid in enumerate(agent_ids):
                 if aid in self.end_of_road_handler._end_of_road_ids:
                     properties[i].waypoints = None

--- a/invertedai/simulation_manager.py
+++ b/invertedai/simulation_manager.py
@@ -355,11 +355,11 @@ class SimulationManager:
         if not self.agents_dict and not external_agent_data:
             raise ValueError("No agents remaining in simulation. All agents have been removed.")
 
-        # dont include end of road agents in DRIVE call
         on_road = (
             {k: v for k, v in self.agents_dict.items()
              if k not in self.end_of_road_handler._end_of_road_ids}
-            if self.end_of_road_handler else self.agents_dict
+            if (self.end_of_road_handler and self.end_of_road_handler.cfg.remove_agent)
+            else self.agents_dict
         )
         agent_ids, states, properties, recurrent_states = self._unpack(on_road)
         if len(recurrent_states) > 0: 
@@ -401,8 +401,14 @@ class SimulationManager:
                 external_ids=external_ids,
             )
 
+        #no more waypoints fro agents that have reached end of road even if they still in simulation
+        if self.end_of_road_handler:
+            for i, aid in enumerate(agent_ids):
+                if aid in self.end_of_road_handler._end_of_road_ids:
+                    properties[i].waypoints = None
+
         if self.waypoint_manager:
-            agents_mask = (
+            agents_mask = ( # mask for end-of-road agents
                 self.end_of_road_handler.get_agents_mask(agent_ids)
                 if self.end_of_road_handler else None
             )
@@ -422,16 +428,8 @@ class SimulationManager:
         )
 
         if self.scene_visualizer is not None:
-            frame_states = list(response.agent_states)
-            frame_props = list(properties)
-            frame_ids = list(agent_ids)
-            if self.end_of_road_handler and not self.end_of_road_handler.cfg.remove_agent:
-                for fid, fdata in self.end_of_road_handler.get_frozen_agents().items():
-                    frame_ids.append(fid)
-                    frame_states.append(fdata.state)
-                    frame_props.append(fdata.properties)
             self._frames.append(FrameData(
-                agents=FrameData.agents_from_lists(frame_states, frame_props, frame_ids),
+                agents=FrameData.agents_from_lists(response.agent_states, properties, agent_ids),
                 traffic_lights=response.traffic_lights_states,
                 agent_tags=self.agent_tags,
             ))
@@ -442,8 +440,6 @@ class SimulationManager:
                 properties=properties,
                 recurrent_states=response.recurrent_states,
             )
-            if self.end_of_road_handler and not self.end_of_road_handler.cfg.remove_agent:
-                all_agents_dict.update(self.end_of_road_handler.get_frozen_agents())
             if self.log_writer is not None:
                 self.log_writer.drive(
                     drive_response=response,

--- a/invertedai/simulation_manager.py
+++ b/invertedai/simulation_manager.py
@@ -40,7 +40,6 @@ class SimulationManager:
             scene_plotter_cfg: Optional[ScenePlotterConfig] = None, # deprecated: use scene_visualizer_cfg instead
             waypoint_cfg : Optional[WaypointManagerConfig] = None, # can optionally initialize a waypointManager to manage waypoints
             log_writer_cfg: Optional[LogWriterConfig] = None, # can optionally initialize a log_writer_cfg to write a json file log of the simulation
-            remove_offroad_agents: bool = False, # if True, agents whose waypoints are empty after update (off-road/end-of-map) will be removed
         ):
             if scene_plotter_cfg is not None:
                 warnings.warn('scene_plotter_cfg is deprecated. Use scene_visualizer_cfg instead.', category=DeprecationWarning)
@@ -64,6 +63,7 @@ class SimulationManager:
             self.agents_dict: SimulationAgentDict = defaultdict(AgentData)
             self.agent_tags: Optional[dict] = None  # Dict[AgentID, AgentTag] — applied to every recorded frame
             self.waypoint_manager: Optional[WaypointManager] = None
+            self.remove_offroad_agents = waypoint_cfg.remove_end_of_road_agents if waypoint_cfg else False
             if waypoint_cfg:
                 self.waypoint_manager = WaypointManager(cfg=waypoint_cfg)
             self.log_writer = None

--- a/invertedai/simulation_manager.py
+++ b/invertedai/simulation_manager.py
@@ -73,6 +73,7 @@ class SimulationManager:
                 self.waypoint_manager = WaypointManager(cfg=waypoint_cfg)
             if end_of_road_cfg:
                 self.end_of_road_handler=EndOfRoadHandler(end_of_road_cfg)
+            self.agents_mask: Optional[List[bool]] = None
             self.log_writer = None
             self.log_writer_cfg = log_writer_cfg
             if log_writer_cfg:
@@ -275,9 +276,11 @@ class SimulationManager:
 
         new_properties = response.agent_properties
         if self.waypoint_manager:
+            self.agents_mask = [True] * len(all_agent_ids)  # default to all True
             new_properties = self.waypoint_manager.update(
                 response = response,
                 agent_properties = response.agent_properties,
+                agents_mask = self.agents_mask
             )
         internal_indices = []
         for i, aid in enumerate(all_agent_ids):
@@ -404,16 +407,13 @@ class SimulationManager:
             for i, aid in enumerate(agent_ids):
                 if aid in self.end_of_road_handler._end_of_road_ids:
                     properties[i].waypoints = None
+            self.agents_mask = self.end_of_road_handler.get_agents_mask(agent_ids)
 
         if self.waypoint_manager:
-            agents_mask = ( # mask for end-of-road agents
-                self.end_of_road_handler.get_agents_mask(agent_ids)
-                if self.end_of_road_handler else None
-            )
             properties = self.waypoint_manager.update(
                 response=response,
                 agent_properties=properties,
-                agents_mask=agents_mask,
+                agents_mask=self.agents_mask,
             )
 
         remove_ids = self.end_of_road_handler._end_of_road_ids if (self.end_of_road_handler and self.end_of_road_handler.cfg.remove_agent) else set()


### PR DESCRIPTION
Created new class `EndOfRoadHandler` as a tool to be used within the `SimulationManager` workflow with its own config `EndOfRoadConfig`. 

This tool takes heavy inspiration from `WaypointManager` in its lanelet logic. 

At its basis it takes in `AgentStates` and a `lanelet_map` from `LocationInfoResponse` and checks for each `AgentState` whether there is a following lanelet in the `lanelet_map` given a certain spacing threshold.
